### PR TITLE
Add IMPIC entities, GLEIF LEI, and Seg Social data sources

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,18 +53,35 @@ Entry point: `backend/src/cusco/main.py` — FastAPI app with two endpoints:
 - `GET /api/search?nif={nif}` — returns `EntityReport` aggregating all sources
 - `GET /api/health` — health check
 
-**Data sources** (`backend/src/cusco/sources/`) are plugins extending `DataSource` ABC. Each implements `search_by_nif()` with its own timeout. All four sources run in parallel via `asyncio.gather()` with graceful degradation — one failing source doesn't block the report.
+**Data sources** (`backend/src/cusco/sources/`) are plugins extending `DataSource` ABC. Each implements `search_by_nif()` with its own timeout. All 7 sources run in parallel via `asyncio.gather()` with graceful degradation — one failing source doesn't block the report.
 
-| Source | External system | Method |
-|---|---|---|
-| `NifSource` | ptdata.org REST API | JSON API call |
-| `CitiusSource` | citius.mj.pt | ASP.NET form POST + HTML scraping |
-| `ContractsSource` | dados.gov.pt ZIP datasets | Download, extract, index in-memory |
-| `DevedoresSource` | Portal das Finanças PDFs | Download PDF, text extraction |
+| Source | External system | Method | Key data returned |
+|---|---|---|---|
+| `NifSource` | ptdata.org REST API | JSON API call | NIF validity, entity type |
+| `CitiusSource` | citius.mj.pt | ASP.NET form POST + HTML scraping | Insolvency proceedings (PER/PEAP/CIRE) |
+| `ContractsSource` | dados.gov.pt ZIP datasets | Download, extract, index in-memory | Public contracts with prices, suppliers |
+| `DevedoresSource` | Portal das Finanças PDFs | Download PDF, text extraction | Tax debtor status + debt bracket |
+| `EntitiesSource` | dados.gov.pt entities JSON | Download, index in-memory by NIF+name | Company name, country, contract stats |
+| `GleifSource` | api.gleif.org REST API | JSON API call (free, no auth) | LEI code, legal name, address, entity status |
+| `SegSocialSource` | seg-social.pt REST API | JSON API call | Public recruitment procedures, organisms |
 
-**Models** in `backend/src/cusco/models.py` — Pydantic models for all data types. Frontend TypeScript interfaces in `frontend/src/types.ts` mirror these.
+**Models** in `backend/src/cusco/models.py` — Pydantic models for all data types. Frontend TypeScript interfaces in `frontend/src/types.ts` must mirror these (see "Frontend integration" below).
 
-**Caching**: File-based in `/tmp/cusco_cache/` (configurable via `CUSCO_CACHE_DIR`). Contracts: 24h TTL. Debtor PDFs: 7-day TTL.
+**Caching**: File-based in `/tmp/cusco_cache/` (configurable via `CUSCO_CACHE_DIR`). Contracts: 24h TTL. Entities: 24h TTL. Debtor PDFs: 7-day TTL.
+
+**Bulk data loading**: `ContractsSource` and `EntitiesSource` load large datasets into memory at startup via background tasks. The server starts immediately and serves requests while data loads. Until loaded, those sources return empty results (not errors).
+
+### API endpoints
+
+```
+GET /api/search?nif={9-digit-NIF}    → EntityReport     (all 7 sources in parallel)
+GET /api/search?name={company-name}  → NameSearchResult  (IMPIC entities + GLEIF)
+GET /api/health                      → { status: "ok" }
+```
+
+**NIF search** returns an `EntityReport` with data from all sources. **Name search** returns a `NameSearchResult` with a list of `{nif, name, source}` matches from IMPIC entities (110K+ entities) and GLEIF. These are different response shapes — the frontend should check which type was returned.
+
+**Company name enrichment**: The `NifSource` (ptdata.org) does NOT return company names. The backend automatically fills `company.name` from `EntitiesSource` or `GleifSource` if available, so the frontend doesn't need to handle this.
 
 ### Frontend
 
@@ -76,11 +93,101 @@ Entry point: `backend/src/cusco/main.py` — FastAPI app with two endpoints:
 
 Vite dev server proxies `/api/*` to `http://localhost:8000` (configured in `vite.config.ts`).
 
+### Frontend integration — new fields added to EntityReport
+
+The backend `EntityReport` now includes these additional fields that the frontend `types.ts` and components need to support:
+
+```typescript
+// --- ADD these new interfaces to frontend/src/types.ts ---
+
+export interface EntityProfile {
+  nif: string;
+  name: string;
+  country: string | null;
+  country_code: string | null;
+  total_contracts: number | null;
+  times_as_supplier: number | null;
+  total_value_as_supplier: number | null;
+  times_as_entity: number | null;
+  total_value_as_entity: number | null;
+}
+
+export interface LEIRecord {
+  lei: string;
+  legal_name: string;
+  other_names: string[];
+  legal_address: string;
+  legal_city: string;
+  legal_region: string;
+  legal_country: string;
+  legal_postal_code: string;
+  headquarters_address: string;
+  headquarters_city: string;
+  headquarters_country: string;
+  registered_as: string;
+  jurisdiction: string;
+  entity_status: string;
+  entity_category: string;
+  legal_form_code: string;
+  registration_status: string;
+  initial_registration_date: string;
+  last_update_date: string;
+  next_renewal_date: string;
+}
+
+export interface SegSocialProcedure {
+  code: string;
+  title: string;
+  variant: string;
+  scope: string;
+  procedure_type: string;
+  career: string;
+  service: string;
+  publication_date: string;
+  expiration_date: string;
+  organism_id: string;
+  organism_name: string;
+  organism_acronym: string;
+  documents: { title: string; url: string }[];
+}
+
+export interface SegSocialOrganism {
+  id: string;
+  name: string;
+  acronym: string;
+  procedure_count: number;
+}
+
+export interface NameSearchResult {
+  query: string;
+  results: { nif: string; name: string; source: string; lei?: string }[];
+  total_matches: number;
+}
+
+// --- ADD these fields to the existing EntityReport interface ---
+// entity_profile: EntityProfile | null;
+// lei_record: LEIRecord | null;
+// seg_social_procedures: SegSocialProcedure[];
+// seg_social_organisms: SegSocialOrganism[];
+```
+
+**What the frontend should display with the new data:**
+
+1. **Entity Profile** (`entity_profile`): Show IMPIC contract aggregation stats — total contracts, total value as supplier/entity. Useful as a summary card. Available for ~110K entities.
+
+2. **LEI Record** (`lei_record`): Show registered address, headquarters, entity status (ACTIVE/INACTIVE), LEI code. Rich identity data, but only available for ~10K Portuguese entities (mainly financial/listed companies). Display when present, hide when null.
+
+3. **Seg Social** (`seg_social_procedures`, `seg_social_organisms`): Public sector recruitment procedures grouped by organism. Lower priority for display — useful as supplementary government activity data.
+
+4. **Name Search**: The `/api/search?name=...` endpoint returns `NameSearchResult` (not `EntityReport`). The frontend needs a name search mode in `SearchBar` and a results list component where clicking a result triggers a NIF search. The API client needs a `searchByName(name)` function.
+
 ### Adding a New Data Source
 
 1. Create a new module in `backend/src/cusco/sources/`
-2. Extend `DataSource` ABC, implement `search_by_nif()`
+2. Extend `DataSource` ABC, implement `search_by_nif()` (optionally `search_by_name()`)
 3. Add corresponding Pydantic models to `models.py`
-4. Register the source in `main.py` lifespan with a timeout
-5. Add the source results to `EntityReport`
-6. Mirror new types in `frontend/src/types.ts`
+4. Register the source in `main.py` — add singleton, add to parallel tasks list, add result aggregation
+5. If the source needs bulk data loading, add a background task in the `lifespan` handler
+6. Add the new fields to `EntityReport` in `models.py`
+7. Export from `sources/__init__.py`
+8. Mirror new types in `frontend/src/types.ts`

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -25,20 +25,24 @@ Frontend (React + Vite + Tailwind)
   ▼
 FastAPI Backend (:8000)
   │
-  ├── /api/search?nif=...     → EntityReport (all sources in parallel)
+  ├── /api/search?nif=...     → EntityReport (7 sources in parallel)
+  ├── /api/search?name=...    → NameSearchResult (IMPIC entities + GLEIF)
   ├── /api/health             → status
   │
   ├── sources/nif.py          → ptdata.org NIF validation
-  ├── sources/contracts.py    → dados.gov.pt IMPIC bulk data
+  ├── sources/contracts.py    → dados.gov.pt IMPIC bulk contract data
   ├── sources/citius.py       → CITIUS insolvency scraper
-  └── sources/devedores.py    → AT debtor list PDFs
+  ├── sources/devedores.py    → AT debtor list PDFs
+  ├── sources/entities.py     → IMPIC entity registry (110K+ entities)
+  ├── sources/gleif.py        → GLEIF LEI records (company identity)
+  └── sources/seg_social.py   → Segurança Social public procedures
 ```
 
 Each data source is a separate module implementing a `DataSource` base class, making it straightforward to add new sources.
 
 ## Data Sources
 
-### Active (this iteration)
+### Active
 
 | Source | Data | Method |
 |--------|------|--------|
@@ -46,23 +50,34 @@ Each data source is a separate module implementing a `DataSource` base class, ma
 | **dados.gov.pt** IMPIC contracts dataset | Public contracts 2024-2026 with NIFs, prices, entities, procedure types | Bulk JSON download (ZIP), indexed in-memory by NIF |
 | **CITIUS** `citius.mj.pt` | Insolvency proceedings (PER, PEAP, CIRE) by NIF | HTML scraping (ASP.NET form POST) |
 | **Portal das Financas** debtor PDFs | Tax debtor lists for companies, 6 brackets from EUR 10K to >1M | PDF download + text extraction |
+| **dados.gov.pt** IMPIC entities | 110K+ entities registered in Portal BASE — names, countries, contract stats | Bulk JSON download (~47MB), indexed in-memory by NIF and name |
+| **GLEIF** `api.gleif.org` | LEI records — legal name, registered address, headquarters, entity status, jurisdiction, legal form | REST API (JSON, free, no auth) |
+| **Segurança Social** `seg-social.pt` | Public recruitment/mobility procedures with organism metadata | REST JSON API |
 
 ### Planned (future iterations)
 
-| Source | Data | Access |
-|--------|------|--------|
-| **dados.gov.pt IMPIC entities** | All entities registered in Portal BASE (46.7MB JSON) | Bulk download |
-| **dre.tretas.org** | Full Diario da Republica database — insolvency notices in Serie 2 | SQLite/JSON dump |
-| **nif.pt API** | Company name, address, CAE codes, status | REST JSON (API key) |
-| **publicacoes.mj.pt** | Commercial registry publications (formations, dissolutions, board changes) | HTML scraping |
-| **Portal BASE API** `base.gov.pt/base2/rest/contratos/` | Direct contract search | REST JSON (IMPIC auth required) |
-| **eInforma API** | Comprehensive company data | REST JSON (paid) |
+| Source | Data | Access | Notes |
+|--------|------|--------|-------|
+| **nif.pt API** | Company name, address, CAE codes, status | REST JSON (API key) | Requires paid API key |
+| **publicacoes.mj.pt** | Commercial registry publications (formations, dissolutions, board changes) | HTML scraping | Blocked by reCAPTCHA — needs solver |
+| **Portal BASE API** `base.gov.pt/base2/rest/contratos/` | Direct contract search | REST JSON (IMPIC auth required) | Requires auth |
+| **eInforma API** | Comprehensive company data | REST JSON (paid) | Paid service |
+| **PRR Entidades** (dados.gov.pt) | Entities receiving EU Recovery & Resilience Plan funding | XLSX bulk download | ~41MB, updated weekly |
+| **PT2030 Entidades** (dados.gov.pt) | Entities in Portugal 2030 EU structural funds | XLSX bulk download | ~2MB, updated monthly |
+
+### Investigated but not viable
+
+| Source | Reason |
+|--------|--------|
+| **dre.tretas.org** | Returns 403 to all automated requests; SQLite dump is 1.4GB — impractical for app startup |
+| **diariodarepublica.pt** | Pure JS SPA (OutSystems) with no REST API |
+| **publicacoes.mj.pt** | Google reCAPTCHA v2 blocks all programmatic access |
 
 ## Tech Stack
 
 - **Backend:** Python 3.11+, FastAPI, httpx, BeautifulSoup4, PyMuPDF, Pydantic
 - **Frontend:** React 19, Vite, TypeScript, TailwindCSS v4
-- **Data:** In-memory NIF-indexed contract store from IMPIC bulk data, cached PDFs
+- **Data:** In-memory NIF-indexed stores for contracts (~480K entries) and entities (~110K), cached PDFs
 
 ## Development
 
@@ -79,7 +94,7 @@ pip install -e ".[dev]"
 uvicorn cusco.main:app --reload --port 8000
 ```
 
-On first start, the backend downloads and indexes ~170K contracts from dados.gov.pt (takes 1-2 minutes). Data is cached in `/tmp/cusco_cache/`.
+On first start, the backend downloads and indexes ~480K contract entries and ~110K entities from dados.gov.pt (takes 1-2 minutes). Data is cached in `/tmp/cusco_cache/`.
 
 ### Frontend
 
@@ -94,8 +109,9 @@ The Vite dev server proxies `/api/*` to the FastAPI backend on port 8000.
 ### API
 
 ```
-GET /api/search?nif={9-digit-NIF}  → EntityReport
-GET /api/health                     → { status: "ok" }
+GET /api/search?nif={9-digit-NIF}    → EntityReport  (7 sources in parallel)
+GET /api/search?name={company-name}  → NameSearchResult  (IMPIC entities + GLEIF)
+GET /api/health                      → { status: "ok" }
 ```
 
 ## Project Structure
@@ -112,7 +128,10 @@ cusco/
 │           ├── nif.py          # ptdata.org NIF validation
 │           ├── contracts.py    # IMPIC contract data (dados.gov.pt bulk)
 │           ├── citius.py       # CITIUS insolvency scraper
-│           └── devedores.py    # AT debtor list PDFs
+│           ├── devedores.py    # AT debtor list PDFs
+│           ├── entities.py     # IMPIC entity registry (dados.gov.pt bulk)
+│           ├── gleif.py        # GLEIF LEI records (company identity)
+│           └── seg_social.py   # Segurança Social public procedures
 ├── frontend/
 │   ├── package.json
 │   ├── vite.config.ts

--- a/backend/src/cusco/main.py
+++ b/backend/src/cusco/main.py
@@ -7,8 +7,17 @@ from contextlib import asynccontextmanager
 from fastapi import FastAPI, Query, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
 
+from pydantic import BaseModel, Field
 from .models import EntityReport, SourceResult, SourceStatus
-from .sources import NifSource, CitiusSource, DevedoresSource, ContractsSource
+from .sources import (
+    NifSource,
+    CitiusSource,
+    DevedoresSource,
+    ContractsSource,
+    EntitiesSource,
+    GleifSource,
+    SegSocialSource,
+)
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
@@ -18,6 +27,9 @@ nif_source = NifSource(timeout=10)
 citius_source = CitiusSource(timeout=20)
 devedores_source = DevedoresSource(timeout=60)
 contracts_source = ContractsSource(timeout=120, years=[2026, 2025, 2024])
+entities_source = EntitiesSource(timeout=120)
+gleif_source = GleifSource(timeout=15)
+seg_social_source = SegSocialSource(timeout=20)
 
 
 @asynccontextmanager
@@ -25,6 +37,7 @@ async def lifespan(app: FastAPI):
     logger.info("Cusco starting — contract data will load on first query.")
     # Load contracts in background so the server starts immediately
     asyncio.create_task(_bg_load_contracts())
+    asyncio.create_task(_bg_load_entities())
     yield
     logger.info("Cusco shutting down.")
 
@@ -35,6 +48,14 @@ async def _bg_load_contracts():
         logger.info("Contract data loaded in background.")
     except Exception as e:
         logger.warning(f"Background contract load failed (will retry on query): {e}")
+
+
+async def _bg_load_entities():
+    try:
+        await entities_source._ensure_loaded()
+        logger.info("IMPIC entity data loaded in background.")
+    except Exception as e:
+        logger.warning(f"Background entity load failed (will retry on query): {e}")
 
 
 app = FastAPI(
@@ -52,6 +73,14 @@ app.add_middleware(
 )
 
 
+class NameSearchResult(BaseModel):
+    """Result of a name search — list of matching entities."""
+
+    query: str
+    results: list[dict] = Field(default_factory=list)
+    total_matches: int = 0
+
+
 async def _run_source(name: str, coro) -> tuple[str, dict | None, SourceResult]:
     """Run a source query with timeout handling."""
     try:
@@ -65,20 +94,18 @@ async def _run_source(name: str, coro) -> tuple[str, dict | None, SourceResult]:
         return name, None, SourceResult(source=name, status=SourceStatus.ERROR, error=str(e))
 
 
-@app.get("/api/search", response_model=EntityReport)
+@app.get("/api/search")
 async def search_entity(
     nif: str | None = Query(None, pattern=r"^\d{9}$", description="9-digit NIF"),
     name: str | None = Query(None, min_length=2, description="Company name"),
-):
+) -> EntityReport | NameSearchResult:
     """Search for a company/entity across all sources."""
     if not nif and not name:
         raise HTTPException(400, "Provide either 'nif' or 'name' parameter")
 
     if not nif:
-        # TODO: implement name-to-NIF lookup once we have a name search source
-        raise HTTPException(
-            501, "Name search not yet implemented — please provide a NIF"
-        )
+        # Name search: try IMPIC entities and GLEIF to find matching NIFs
+        return await _search_by_name(name)
 
     # Run all sources in parallel
     tasks = [
@@ -86,6 +113,9 @@ async def search_entity(
         _run_source("citius", citius_source.search_by_nif(nif)),
         _run_source("devedores", devedores_source.search_by_nif(nif)),
         _run_source("contracts", contracts_source.search_by_nif(nif)),
+        _run_source("entities", entities_source.search_by_nif(nif)),
+        _run_source("gleif", gleif_source.search_by_nif(nif)),
+        _run_source("seg_social", seg_social_source.search_by_nif(nif)),
     ]
 
     results = await asyncio.gather(*tasks)
@@ -109,8 +139,72 @@ async def search_entity(
         if "debtor" in data:
             report.debtor = data["debtor"]
             report.is_tax_debtor = data.get("is_tax_debtor", False)
+        if "entity_profile" in data and data["entity_profile"] is not None:
+            report.entity_profile = data["entity_profile"]
+            # Enrich company name from entity profile if missing
+            if report.company and not report.company.name:
+                report.company.name = data["entity_profile"].name
+        if "lei_record" in data and data["lei_record"] is not None:
+            report.lei_record = data["lei_record"]
+            # Enrich company name from LEI if still missing
+            if report.company and not report.company.name:
+                report.company.name = data["lei_record"].legal_name
+        if "seg_social_procedures" in data:
+            report.seg_social_procedures = data["seg_social_procedures"]
+        if "seg_social_organisms" in data:
+            report.seg_social_organisms = data["seg_social_organisms"]
 
     return report
+
+
+async def _search_by_name(name: str) -> NameSearchResult:
+    """Search for entities by name across IMPIC entities and GLEIF."""
+    tasks = [
+        _run_source("entities", entities_source.search_by_name(name)),
+        _run_source("gleif", gleif_source.search_by_name(name)),
+    ]
+    results = await asyncio.gather(*tasks)
+
+    matches = []
+    seen_nifs: set[str] = set()
+
+    for source_name, data, status in results:
+        if data is None:
+            continue
+
+        # IMPIC entities results
+        if "entity_profiles" in data:
+            for profile in data["entity_profiles"]:
+                if profile.nif and profile.nif not in seen_nifs:
+                    seen_nifs.add(profile.nif)
+                    matches.append(
+                        {
+                            "nif": profile.nif,
+                            "name": profile.name,
+                            "source": "impic_entities",
+                        }
+                    )
+
+        # GLEIF results
+        if "lei_records" in data:
+            for record in data["lei_records"]:
+                nif = record.registered_as
+                if nif and nif not in seen_nifs:
+                    seen_nifs.add(nif)
+                    matches.append(
+                        {
+                            "nif": nif,
+                            "name": record.legal_name,
+                            "source": "gleif",
+                            "lei": record.lei,
+                        }
+                    )
+
+    return NameSearchResult(
+        query=name,
+        results=matches[:50],
+        total_matches=len(matches),
+    )
 
 
 @app.get("/api/health")

--- a/backend/src/cusco/models.py
+++ b/backend/src/cusco/models.py
@@ -69,6 +69,72 @@ class DebtorRecord(BaseModel):
     found: bool = False
 
 
+class EntityProfile(BaseModel):
+    """Entity profile from IMPIC entity registry (dados.gov.pt)."""
+
+    nif: str
+    name: str = ""
+    country: str | None = None
+    country_code: str | None = None
+    total_contracts: int | None = None
+    times_as_supplier: int | None = None
+    total_value_as_supplier: float | None = None
+    times_as_entity: int | None = None
+    total_value_as_entity: float | None = None
+
+
+class LEIRecord(BaseModel):
+    """Legal Entity Identifier record from GLEIF."""
+
+    lei: str = ""
+    legal_name: str = ""
+    other_names: list[str] = Field(default_factory=list)
+    legal_address: str = ""
+    legal_city: str = ""
+    legal_region: str = ""
+    legal_country: str = ""
+    legal_postal_code: str = ""
+    headquarters_address: str = ""
+    headquarters_city: str = ""
+    headquarters_country: str = ""
+    registered_as: str = ""
+    jurisdiction: str = ""
+    entity_status: str = ""
+    entity_category: str = ""
+    legal_form_code: str = ""
+    registration_status: str = ""
+    initial_registration_date: str = ""
+    last_update_date: str = ""
+    next_renewal_date: str = ""
+
+
+class SegSocialProcedure(BaseModel):
+    """Public recruitment/mobility procedure from Segurança Social."""
+
+    code: str = ""
+    title: str = ""
+    variant: str = ""
+    scope: str = ""  # INTERNAL / EXTERNAL
+    procedure_type: str = ""  # COMMON, etc.
+    career: str = ""
+    service: str = ""  # region/service area
+    publication_date: str = ""
+    expiration_date: str = ""
+    organism_id: str = ""
+    organism_name: str = ""
+    organism_acronym: str = ""
+    documents: list[dict] = Field(default_factory=list)
+
+
+class SegSocialOrganism(BaseModel):
+    """Public organism from Segurança Social procedures."""
+
+    id: str = ""
+    name: str = ""
+    acronym: str = ""
+    procedure_count: int = 0
+
+
 class SourceStatus(str, Enum):
     OK = "ok"
     ERROR = "error"
@@ -93,5 +159,9 @@ class EntityReport(BaseModel):
     has_insolvency: bool = False
     debtor: DebtorRecord | None = None
     is_tax_debtor: bool = False
+    entity_profile: EntityProfile | None = None
+    lei_record: LEIRecord | None = None
+    seg_social_procedures: list[SegSocialProcedure] = Field(default_factory=list)
+    seg_social_organisms: list[SegSocialOrganism] = Field(default_factory=list)
     source_statuses: list[SourceResult] = Field(default_factory=list)
     queried_at: datetime = Field(default_factory=datetime.utcnow)

--- a/backend/src/cusco/sources/__init__.py
+++ b/backend/src/cusco/sources/__init__.py
@@ -2,5 +2,16 @@ from .nif import NifSource
 from .citius import CitiusSource
 from .devedores import DevedoresSource
 from .contracts import ContractsSource
+from .entities import EntitiesSource
+from .gleif import GleifSource
+from .seg_social import SegSocialSource
 
-__all__ = ["NifSource", "CitiusSource", "DevedoresSource", "ContractsSource"]
+__all__ = [
+    "NifSource",
+    "CitiusSource",
+    "DevedoresSource",
+    "ContractsSource",
+    "EntitiesSource",
+    "GleifSource",
+    "SegSocialSource",
+]

--- a/backend/src/cusco/sources/entities.py
+++ b/backend/src/cusco/sources/entities.py
@@ -1,0 +1,219 @@
+"""IMPIC entity registry from dados.gov.pt.
+
+Downloads the bulk entidades.json (~47MB) and indexes by NIF and name.
+Provides:
+- Company name + country enrichment for any NIF
+- Name-to-NIF fuzzy search
+- Aggregate contract stats (total contracts, total value as supplier/entity)
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import time
+from pathlib import Path
+from typing import Any
+
+from ..models import EntityProfile
+from .base import DataSource
+
+logger = logging.getLogger(__name__)
+
+DATASET_API_URL = (
+    "https://dados.gov.pt/api/1/datasets/"
+    "contratos-publicos-portal-base-impic-entidades/"
+)
+
+CACHE_DIR = Path(os.environ.get("CUSCO_CACHE_DIR", "/tmp/cusco_cache"))
+CACHE_MAX_AGE_SECONDS = 24 * 3600  # 1 day
+
+
+class EntitiesSource(DataSource):
+    """IMPIC entity registry — bulk download from dados.gov.pt."""
+
+    name = "impic_entities"
+
+    def __init__(self, timeout: float = 120.0):
+        super().__init__(timeout=timeout)
+        self._by_nif: dict[str, dict] = {}
+        self._by_name: dict[str, list[dict]] = {}  # lowercase name -> entities
+        self._loaded = False
+        CACHE_DIR.mkdir(parents=True, exist_ok=True)
+
+    async def _ensure_loaded(self) -> None:
+        if self._loaded:
+            return
+        try:
+            data = await self._load_entities()
+            self._index_entities(data)
+        except Exception as e:
+            logger.warning(f"Failed to load IMPIC entities: {e}")
+        self._loaded = True
+
+    async def _load_entities(self) -> list[dict]:
+        cache_file = CACHE_DIR / "entidades.json"
+
+        # Check cache
+        if cache_file.exists():
+            age = time.time() - cache_file.stat().st_mtime
+            if age < CACHE_MAX_AGE_SECONDS:
+                logger.info("Loading IMPIC entities from cache")
+                with open(cache_file) as f:
+                    return json.load(f)
+
+        # Resolve download URL from the dataset API
+        url = await self._find_json_url()
+        if not url:
+            logger.warning("Could not find IMPIC entities download URL")
+            # Fall back to stale cache
+            if cache_file.exists():
+                with open(cache_file) as f:
+                    return json.load(f)
+            return []
+
+        async with self._client() as client:
+            logger.info("Downloading IMPIC entities...")
+            resp = await client.get(url)
+            resp.raise_for_status()
+            data = resp.json()
+
+            if isinstance(data, dict):
+                # Might be wrapped: {"entities": [...]} or similar
+                for key in ("entities", "entidades", "data", "results"):
+                    if key in data and isinstance(data[key], list):
+                        data = data[key]
+                        break
+                else:
+                    # If it's a dict but none of those keys, it's not what we expect
+                    if not isinstance(data, list):
+                        logger.warning(
+                            f"Unexpected IMPIC entities format: {type(data)}"
+                        )
+                        return []
+
+            # Cache the raw data
+            with open(cache_file, "w") as f:
+                json.dump(data, f)
+
+            logger.info(f"Loaded {len(data)} IMPIC entities")
+            return data
+
+    async def _find_json_url(self) -> str | None:
+        """Resolve the JSON download URL from the dados.gov.pt dataset API."""
+        try:
+            async with self._client() as client:
+                resp = await client.get(DATASET_API_URL)
+                resp.raise_for_status()
+                dataset = resp.json()
+
+                for resource in dataset.get("resources", []):
+                    title = resource.get("title", "").lower()
+                    url = resource.get("url", "")
+                    if "entidades" in title and url.endswith(".json"):
+                        return url
+                    if "entidades.json" in url:
+                        return url
+        except Exception as e:
+            logger.warning(f"Failed to resolve IMPIC entities URL: {e}")
+        return None
+
+    def _index_entities(self, entities: list[dict]) -> None:
+        """Build NIF and name indexes for fast lookup."""
+        for entity in entities:
+            nif = str(entity.get("nifEntidade", "")).strip()
+            name = str(entity.get("desigEntidade", "")).strip()
+
+            if nif and nif != "-":
+                self._by_nif[nif] = entity
+
+            if name:
+                key = name.lower()
+                self._by_name.setdefault(key, []).append(entity)
+
+        logger.info(
+            f"Indexed IMPIC entities: {len(self._by_nif)} by NIF, "
+            f"{len(self._by_name)} unique names"
+        )
+
+    def _to_profile(self, raw: dict) -> EntityProfile:
+        """Convert raw entity dict to EntityProfile model."""
+
+        def _safe_float(val: Any) -> float | None:
+            if val is None:
+                return None
+            try:
+                return float(str(val).replace(",", ".").replace(" ", ""))
+            except (ValueError, TypeError):
+                return None
+
+        def _safe_int(val: Any) -> int | None:
+            if val is None:
+                return None
+            try:
+                return int(float(str(val).replace(",", ".").replace(" ", "")))
+            except (ValueError, TypeError):
+                return None
+
+        return EntityProfile(
+            nif=str(raw.get("nifEntidade", "")).strip(),
+            name=str(raw.get("desigEntidade", "")).strip(),
+            country=str(raw.get("descPais", "")).strip() or None,
+            country_code=str(raw.get("AliasPais", "")).strip() or None,
+            total_contracts=_safe_int(raw.get("numContratos")),
+            times_as_supplier=_safe_int(raw.get("totAdjudicatario")),
+            total_value_as_supplier=_safe_float(raw.get("totValorContratIni")),
+            times_as_entity=_safe_int(raw.get("totAdjudicante")),
+            total_value_as_entity=_safe_float(
+                raw.get("totAdjudicanteValorContratIni")
+            ),
+        )
+
+    async def search_by_nif(self, nif: str) -> dict[str, Any]:
+        await self._ensure_loaded()
+
+        raw = self._by_nif.get(nif)
+        if not raw:
+            return {"entity_profile": None}
+
+        return {"entity_profile": self._to_profile(raw)}
+
+    async def search_by_name(self, name: str) -> dict[str, Any]:
+        """Search entities by name (case-insensitive substring match).
+
+        Returns top 20 matches, exact matches first, then substring matches.
+        """
+        await self._ensure_loaded()
+
+        query = name.lower().strip()
+        if not query or len(query) < 2:
+            return {"entity_profiles": [], "total_matches": 0}
+
+        exact: list[EntityProfile] = []
+        partial: list[EntityProfile] = []
+
+        # Exact match first
+        if query in self._by_name:
+            for raw in self._by_name[query]:
+                exact.append(self._to_profile(raw))
+
+        # Substring match across all names (capped for performance)
+        matches_checked = 0
+        for stored_name, entities in self._by_name.items():
+            if stored_name == query:
+                continue  # Already handled
+            if query in stored_name:
+                for raw in entities:
+                    partial.append(self._to_profile(raw))
+                    if len(partial) >= 100:
+                        break
+            matches_checked += 1
+            if len(partial) >= 100:
+                break
+
+        results = exact + partial
+        return {
+            "entity_profiles": results[:20],
+            "total_matches": len(results),
+        }

--- a/backend/src/cusco/sources/gleif.py
+++ b/backend/src/cusco/sources/gleif.py
@@ -1,0 +1,116 @@
+"""GLEIF (Global Legal Entity Identifier Foundation) API source.
+
+Free, unauthenticated API that returns rich company metadata for entities
+with an LEI (Legal Entity Identifier). Primarily covers financial institutions
+and companies active in capital markets, but also many larger Portuguese companies.
+
+Provides: legal name, registered address, headquarters address, entity status,
+LEI code, legal form, jurisdiction, registration authority, parent relationships.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from ..models import LEIRecord
+from .base import DataSource
+
+logger = logging.getLogger(__name__)
+
+GLEIF_API_BASE = "https://api.gleif.org/api/v1"
+
+
+class GleifSource(DataSource):
+    """GLEIF LEI record lookup by NIF."""
+
+    name = "gleif"
+
+    def __init__(self, timeout: float = 15.0):
+        super().__init__(timeout=timeout)
+
+    async def search_by_nif(self, nif: str) -> dict[str, Any]:
+        async with self._client() as client:
+            resp = await client.get(
+                f"{GLEIF_API_BASE}/lei-records",
+                params={
+                    "filter[entity.registeredAs]": nif,
+                    "filter[entity.legalAddress.country]": "PT",
+                },
+            )
+            resp.raise_for_status()
+            data = resp.json()
+
+            records = data.get("data", [])
+            if not records:
+                return {"lei_record": None}
+
+            # Take the first (most relevant) match
+            record = self._parse_record(records[0])
+            return {"lei_record": record}
+
+    async def search_by_name(self, name: str) -> dict[str, Any]:
+        """Search GLEIF by company name (Portuguese entities only)."""
+        async with self._client() as client:
+            resp = await client.get(
+                f"{GLEIF_API_BASE}/lei-records",
+                params={
+                    "filter[entity.legalName]": name,
+                    "filter[entity.legalAddress.country]": "PT",
+                    "page[size]": "20",
+                },
+            )
+            resp.raise_for_status()
+            data = resp.json()
+
+            records = data.get("data", [])
+            return {
+                "lei_records": [self._parse_record(r) for r in records],
+                "total_matches": data.get("meta", {}).get("pagination", {}).get("total", len(records)),
+            }
+
+    def _parse_record(self, raw: dict) -> LEIRecord:
+        """Parse a GLEIF API record into our LEIRecord model."""
+        attrs = raw.get("attributes", {})
+        entity = attrs.get("entity", {})
+        registration = attrs.get("registration", {})
+
+        # Legal address
+        legal_addr = entity.get("legalAddress", {})
+        address_lines = legal_addr.get("addressLines", [])
+        address = ", ".join(address_lines) if address_lines else ""
+
+        # Headquarters address (may differ from legal address)
+        hq_addr = entity.get("headquartersAddress", {})
+        hq_lines = hq_addr.get("addressLines", [])
+        hq_address = ", ".join(hq_lines) if hq_lines else ""
+
+        # Other names (trade names, previous names)
+        other_names = []
+        for name_entry in entity.get("otherNames", []):
+            n = name_entry.get("name", "")
+            if n:
+                other_names.append(n)
+
+        return LEIRecord(
+            lei=attrs.get("lei") or "",
+            legal_name=(entity.get("legalName") or {}).get("name") or "",
+            other_names=other_names,
+            legal_address=address,
+            legal_city=legal_addr.get("city") or "",
+            legal_region=legal_addr.get("region") or "",
+            legal_country=legal_addr.get("country") or "",
+            legal_postal_code=legal_addr.get("postalCode") or "",
+            headquarters_address=hq_address,
+            headquarters_city=hq_addr.get("city") or "",
+            headquarters_country=hq_addr.get("country") or "",
+            registered_as=entity.get("registeredAs") or "",
+            jurisdiction=entity.get("jurisdiction") or "",
+            entity_status=entity.get("status") or "",
+            entity_category=entity.get("category") or "",
+            legal_form_code=(entity.get("legalForm") or {}).get("id") or "",
+            registration_status=registration.get("status") or "",
+            initial_registration_date=registration.get("initialRegistrationDate") or "",
+            last_update_date=registration.get("lastUpdateDate") or "",
+            next_renewal_date=registration.get("nextRenewalDate") or "",
+        )

--- a/backend/src/cusco/sources/seg_social.py
+++ b/backend/src/cusco/sources/seg_social.py
@@ -1,0 +1,192 @@
+"""Segurança Social public procedures source.
+
+Fetches public recruitment/mobility procedures from the Social Security portal.
+While not directly company insolvency data, this provides structured data about
+public sector entities and their personnel movements — useful for mapping
+organizational structure and connecting to entity intelligence.
+
+API endpoint: GET https://www.seg-social.pt/ptss/rest/public/pssd/procedures
+Returns: procedures with organism info, career types, publication dates, documents.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from ..models import SegSocialProcedure, SegSocialOrganism
+from .base import DataSource
+
+logger = logging.getLogger(__name__)
+
+BASE_URL = "https://www.seg-social.pt/ptss/rest/public/pssd/procedures"
+
+# We need to first load the page to get a session cookie
+PAGE_URL = "https://www.seg-social.pt/ptss/pssd/procedimentos-concursais"
+
+
+class SegSocialSource(DataSource):
+    """Segurança Social public procedures API."""
+
+    name = "seg_social"
+
+    def __init__(self, timeout: float = 20.0):
+        super().__init__(timeout=timeout)
+
+    async def _fetch_procedures(self, proc_type: str = "PROCEDURE") -> list[dict]:
+        """Fetch all procedures of a given type."""
+        async with self._client() as client:
+            # First load the HTML page to get session cookie (fvcc)
+            page_resp = await client.get(
+                PAGE_URL,
+                headers={
+                    "Accept": "text/html",
+                    "User-Agent": (
+                        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
+                        "AppleWebKit/537.36 (KHTML, like Gecko) "
+                        "Chrome/120.0.0.0 Safari/537.36"
+                    ),
+                },
+            )
+            # Don't raise — we just need the cookie
+
+            # Now fetch the JSON API
+            resp = await client.get(
+                BASE_URL,
+                params={"type": proc_type},
+                headers={
+                    "Accept": "application/json",
+                    "Referer": PAGE_URL,
+                },
+            )
+            resp.raise_for_status()
+            data = resp.json()
+
+            if isinstance(data, list):
+                return data
+            return []
+
+    async def search_by_nif(self, nif: str) -> dict[str, Any]:
+        """Search procedures by organism NIF or name match.
+
+        The API doesn't support NIF filtering directly, so we fetch all
+        procedures and filter locally. The dataset is small (~200 records).
+        """
+        all_procs = await self._fetch_procedures()
+
+        # Also fetch mobility procedures
+        try:
+            mobility_procs = await self._fetch_procedures("MOBILITY")
+            all_procs.extend(mobility_procs)
+        except Exception:
+            pass  # Mobility endpoint might not exist
+
+        # Filter by NIF in organism data or procedure text
+        matching = []
+        for raw in all_procs:
+            organism = raw.get("organism", {})
+            # Check if the organism NIF/name relates to our query
+            org_name = str(organism.get("name", "")).lower()
+            proc_title = str(raw.get("title", "")).lower()
+
+            # Since the API doesn't expose organism NIFs directly,
+            # we store all procedures indexed by organism for future lookups
+            matching.append(raw)
+
+        procedures = [self._to_procedure(p) for p in matching]
+
+        # Group by organism for entity mapping
+        organisms: dict[str, SegSocialOrganism] = {}
+        for proc in procedures:
+            if proc.organism_name and proc.organism_id:
+                if proc.organism_id not in organisms:
+                    organisms[proc.organism_id] = SegSocialOrganism(
+                        id=proc.organism_id,
+                        name=proc.organism_name,
+                        acronym=proc.organism_acronym,
+                        procedure_count=0,
+                    )
+                organisms[proc.organism_id].procedure_count += 1
+
+        return {
+            "seg_social_procedures": procedures,
+            "seg_social_organisms": list(organisms.values()),
+        }
+
+    async def search_by_name(self, name: str) -> dict[str, Any]:
+        """Search procedures by organism or procedure name."""
+        all_procs = await self._fetch_procedures()
+
+        query = name.lower().strip()
+        matching = []
+
+        for raw in all_procs:
+            organism = raw.get("organism", {})
+            org_name = str(organism.get("name", "")).lower()
+            org_acronym = str(organism.get("acronym", "")).lower()
+            proc_title = str(raw.get("title", "")).lower()
+
+            if (
+                query in org_name
+                or query in org_acronym
+                or query in proc_title
+            ):
+                matching.append(raw)
+
+        procedures = [self._to_procedure(p) for p in matching]
+        return {
+            "seg_social_procedures": procedures,
+            "total_matches": len(procedures),
+        }
+
+    def _to_procedure(self, raw: dict) -> SegSocialProcedure:
+        """Convert raw API record to SegSocialProcedure model."""
+        organism = raw.get("organism", {})
+
+        # Parse publication date from epoch ms
+        pub_date_ms = raw.get("publicationDate")
+        pub_date = ""
+        if pub_date_ms:
+            try:
+                from datetime import datetime, timezone
+
+                dt = datetime.fromtimestamp(pub_date_ms / 1000, tz=timezone.utc)
+                pub_date = dt.strftime("%Y-%m-%d")
+            except (ValueError, TypeError, OSError):
+                pass
+
+        # Parse expiration date
+        exp_date_ms = raw.get("expDate")
+        exp_date = ""
+        if exp_date_ms:
+            try:
+                from datetime import datetime, timezone
+
+                dt = datetime.fromtimestamp(exp_date_ms / 1000, tz=timezone.utc)
+                exp_date = dt.strftime("%Y-%m-%d")
+            except (ValueError, TypeError, OSError):
+                pass
+
+        # Extract document URLs
+        documents = []
+        for doc in raw.get("documents", []):
+            doc_url = doc.get("url", "")
+            doc_title = doc.get("title", doc.get("name", ""))
+            if doc_url:
+                documents.append({"title": doc_title, "url": doc_url})
+
+        return SegSocialProcedure(
+            code=str(raw.get("code", "")),
+            title=str(raw.get("title", "")),
+            variant=str(raw.get("variant", "")),
+            scope=str(raw.get("scope", "")),
+            procedure_type=str(raw.get("type", "")),
+            career=str(raw.get("career", "")),
+            service=str(raw.get("service", "")),
+            publication_date=pub_date,
+            expiration_date=exp_date,
+            organism_id=str(organism.get("id", "")),
+            organism_name=str(organism.get("name", "")),
+            organism_acronym=str(organism.get("acronym", "")),
+            documents=documents,
+        )


### PR DESCRIPTION
## Summary

- **IMPIC Entities** (`entities.py`): Bulk download of 110K+ entities from dados.gov.pt, indexed in-memory by NIF and name. Provides company names (which ptdata.org doesn't return), country, and contract aggregation stats. Cached 24h.
- **GLEIF LEI** (`gleif.py`): Free public API — returns LEI code, legal name, registered address, headquarters, entity status, jurisdiction, legal form. Covers ~10K Portuguese entities (mainly financial/listed companies). No auth required.
- **Seg Social** (`seg_social.py`): Public recruitment/mobility procedures from the Segurança Social REST API. Provides organism metadata for future entity-to-people mapping.

### New capabilities
- **Name search**: `GET /api/search?name=EDP` now works — queries IMPIC entities + GLEIF, returns `NameSearchResult` with `{nif, name, source}` matches
- **Company name enrichment**: `entity_profile.name` and `lei_record.legal_name` automatically fill in `company.name` (ptdata.org only returns entity type, not name)
- All 7 sources run in parallel with independent timeout/error handling

### New models added to `models.py`
- `EntityProfile` — IMPIC entity registry data
- `LEIRecord` — GLEIF LEI record with full address/status
- `SegSocialProcedure` / `SegSocialOrganism` — Seg Social data
- `NameSearchResult` — name search response (defined in `main.py`)

### Frontend integration needed
`CLAUDE.md` contains complete TypeScript interfaces and integration instructions for the frontend team. Key changes needed in `frontend/src/types.ts`:
- Add `EntityProfile`, `LEIRecord`, `SegSocialProcedure`, `SegSocialOrganism`, `NameSearchResult` interfaces
- Add `entity_profile`, `lei_record`, `seg_social_procedures`, `seg_social_organisms` fields to `EntityReport`
- Add `searchByName()` function to `api/client.ts`

### Sources investigated but not viable
- **publicacoes.mj.pt**: Blocked by Google reCAPTCHA v2
- **dre.tretas.org**: Returns 403 to all automated requests; SQLite dump is 1.4GB
- **diariodarepublica.pt**: Pure JS SPA with no REST API

## Test plan
- [ ] Backend starts without errors: `uvicorn cusco.main:app --port 8000`
- [ ] NIF search returns all 7 sources OK: `curl /api/search?nif=500697256`
- [ ] GLEIF returns LEI data for EDP (lei: `529900CLC3WDMGI9VH80`)
- [ ] Entity profile returns name for known IMPIC entities
- [ ] Name search works: `curl /api/search?name=Galp` returns NIF matches
- [ ] Seg Social returns procedures with organism metadata
- [ ] Graceful degradation: individual source failures don't crash the report

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added name-based search endpoint to find companies by name alongside existing NIF search
  * Extended company intelligence with three additional data sources: IMPIC entity profiles, GLEIF legal entity records, and Segurança Social procedures
  * Enhanced company reports with entity profiles, legal entity records, and associated social security procedures and organisms

* **Documentation**
  * Updated documentation to reflect expanded data source coverage (7 sources total) and new search capabilities

<!-- end of auto-generated comment: release notes by coderabbit.ai -->