### PR TITLE
Connect frontend to new data sources and add name search

### DIFF
--- a/dev.sh
+++ b/dev.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+# Start both backend and frontend for development
+# Usage: ./dev.sh
+
+set -e
+
+ROOT="$(cd "$(dirname "$0")" && pwd)"
+
+cleanup() {
+  echo ""
+  echo "Shutting down..."
+  kill $BACKEND_PID $FRONTEND_PID 2>/dev/null
+  wait $BACKEND_PID $FRONTEND_PID 2>/dev/null
+  echo "Done."
+}
+trap cleanup EXIT INT TERM
+
+# --- Backend ---
+echo "==> Installing backend dependencies..."
+cd "$ROOT/backend"
+pip install -e ".[dev]" --quiet 2>/dev/null
+
+echo "==> Starting backend on :8000..."
+cd "$ROOT/backend"
+python3 -m uvicorn cusco.main:app --reload --port 8000 &
+BACKEND_PID=$!
+
+# --- Frontend ---
+echo "==> Installing frontend dependencies..."
+cd "$ROOT/frontend"
+npm install --silent 2>/dev/null
+
+echo "==> Starting frontend on :5173..."
+cd "$ROOT/frontend"
+npm run dev &
+FRONTEND_PID=$!
+
+echo ""
+echo "=================================="
+echo "  Backend:  http://localhost:8000"
+echo "  Frontend: http://localhost:5173"
+echo "  Press Ctrl+C to stop both"
+echo "=================================="
+
+wait

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2,18 +2,24 @@ import { useState } from "react";
 import { SearchBar } from "./components/SearchBar";
 import { EntityReport } from "./components/EntityReport";
 import { ChatPanel } from "./components/ChatPanel";
-import { searchByNif } from "./api/client";
-import type { EntityReport as EntityReportType } from "./types";
+import { searchByNif, searchByName } from "./api/client";
+import type {
+  EntityReport as EntityReportType,
+  NameSearchMatch,
+} from "./types";
 
 export default function App() {
   const [report, setReport] = useState<EntityReportType | null>(null);
   const [loading, setLoading] = useState(false);
+  const [nameLoading, setNameLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [nameResults, setNameResults] = useState<NameSearchMatch[]>([]);
 
-  const handleSearch = async (nif: string) => {
+  const handleSearchNif = async (nif: string) => {
     setLoading(true);
     setError(null);
     setReport(null);
+    setNameResults([]);
     try {
       const result = await searchByNif(nif);
       setReport(result);
@@ -21,6 +27,24 @@ export default function App() {
       setError(e instanceof Error ? e.message : "Something went wrong");
     } finally {
       setLoading(false);
+    }
+  };
+
+  const handleSearchName = async (name: string) => {
+    setNameLoading(true);
+    setError(null);
+    setNameResults([]);
+    try {
+      const result = await searchByName(name);
+      if (result.results.length === 0) {
+        setError(`No entities found matching "${name}"`);
+      } else {
+        setNameResults(result.results);
+      }
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Name search failed");
+    } finally {
+      setNameLoading(false);
     }
   };
 
@@ -36,7 +60,13 @@ export default function App() {
       </header>
 
       <main className="max-w-5xl mx-auto px-4 py-8 space-y-8">
-        <SearchBar onSearch={handleSearch} loading={loading} />
+        <SearchBar
+          onSearchNif={handleSearchNif}
+          onSearchName={handleSearchName}
+          nameResults={nameResults}
+          loading={loading}
+          nameLoading={nameLoading}
+        />
 
         {error && (
           <div className="max-w-2xl mx-auto p-4 bg-red-50 border border-red-200 rounded-lg text-red-700">
@@ -54,12 +84,12 @@ export default function App() {
           </>
         )}
 
-        {!report && !loading && !error && (
+        {!report && !loading && !error && nameResults.length === 0 && (
           <div className="text-center text-gray-400 mt-16">
-            <p className="text-lg">Search a NIF to get started</p>
+            <p className="text-lg">Search by NIF or company name</p>
             <p className="text-sm mt-2">
-              Aggregates data from CITIUS, Portal das Financas, and IMPIC public
-              contracts
+              Aggregates data from CITIUS, Portal das Finanças, IMPIC, GLEIF,
+              and more
             </p>
           </div>
         )}

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -1,9 +1,18 @@
-import type { ChatMessage, EntityReport } from "../types";
+import type { ChatMessage, EntityReport, NameSearchResult } from "../types";
 
 const BASE = "/api";
 
 export async function searchByNif(nif: string): Promise<EntityReport> {
   const res = await fetch(`${BASE}/search?nif=${encodeURIComponent(nif)}`);
+  if (!res.ok) {
+    const err = await res.json().catch(() => ({ detail: res.statusText }));
+    throw new Error(err.detail || `Error ${res.status}`);
+  }
+  return res.json();
+}
+
+export async function searchByName(name: string): Promise<NameSearchResult> {
+  const res = await fetch(`${BASE}/search?name=${encodeURIComponent(name)}`);
   if (!res.ok) {
     const err = await res.json().catch(() => ({ detail: res.statusText }));
     throw new Error(err.detail || `Error ${res.status}`);

--- a/frontend/src/components/EntityProfileCard.tsx
+++ b/frontend/src/components/EntityProfileCard.tsx
@@ -1,0 +1,73 @@
+import type { EntityProfile } from "../types";
+
+interface Props {
+  profile: EntityProfile;
+}
+
+function formatEUR(value: number | null | undefined): string {
+  if (value == null) return "-";
+  return new Intl.NumberFormat("pt-PT", {
+    style: "currency",
+    currency: "EUR",
+    maximumFractionDigits: 0,
+  }).format(value);
+}
+
+export function EntityProfileCard({ profile }: Props) {
+  return (
+    <div className="bg-white rounded-lg border p-6">
+      <h3 className="text-lg font-semibold mb-4 flex items-center gap-2">
+        IMPIC Entity Profile
+        {profile.country && (
+          <span className="px-2 py-0.5 text-xs bg-gray-100 text-gray-600 rounded-full">
+            {profile.country}
+          </span>
+        )}
+      </h3>
+
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+        <div>
+          <p className="text-xs text-gray-500 uppercase tracking-wide">
+            Total Contracts
+          </p>
+          <p className="text-xl font-bold text-gray-900 mt-1">
+            {profile.total_contracts ?? "-"}
+          </p>
+        </div>
+        <div>
+          <p className="text-xs text-gray-500 uppercase tracking-wide">
+            As Supplier
+          </p>
+          <p className="text-lg font-semibold text-gray-800 mt-1">
+            {profile.times_as_supplier ?? "-"}
+            <span className="text-sm font-normal text-gray-500 ml-1">times</span>
+          </p>
+          <p className="text-sm text-gray-600">
+            {formatEUR(profile.total_value_as_supplier)}
+          </p>
+        </div>
+        <div>
+          <p className="text-xs text-gray-500 uppercase tracking-wide">
+            As Contracting Entity
+          </p>
+          <p className="text-lg font-semibold text-gray-800 mt-1">
+            {profile.times_as_entity ?? "-"}
+            <span className="text-sm font-normal text-gray-500 ml-1">times</span>
+          </p>
+          <p className="text-sm text-gray-600">
+            {formatEUR(profile.total_value_as_entity)}
+          </p>
+        </div>
+        <div>
+          <p className="text-xs text-gray-500 uppercase tracking-wide">
+            Country
+          </p>
+          <p className="text-lg font-semibold text-gray-800 mt-1">
+            {profile.country_code ?? "-"}
+          </p>
+          <p className="text-sm text-gray-600">{profile.country ?? ""}</p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/EntityReport.tsx
+++ b/frontend/src/components/EntityReport.tsx
@@ -246,11 +246,12 @@ export function EntityReport({ report }: Props) {
         totalValue={report.contracts_total_value}
       />
 
-      {/* Seg Social */}
+      {/* Seg Social — hidden until connected to entity-level intelligence
       <SegSocialSection
         procedures={report.seg_social_procedures ?? []}
         organisms={report.seg_social_organisms ?? []}
       />
+      */}
     </div>
   );
 }

--- a/frontend/src/components/EntityReport.tsx
+++ b/frontend/src/components/EntityReport.tsx
@@ -3,6 +3,8 @@ import type { EntityReport as EntityReportType } from "../types";
 import { InsolvencyBadge } from "./InsolvencyBadge";
 import { DebtorStatus } from "./DebtorStatus";
 import { ContractsList } from "./ContractsList";
+import { EntityProfileCard } from "./EntityProfileCard";
+import { LEICard } from "./LEICard";
 
 interface Props {
   report: EntityReportType;
@@ -55,6 +57,96 @@ function IberinformSection({ content }: { content: string }) {
   );
 }
 
+function SegSocialSection({
+  procedures,
+  organisms,
+}: {
+  procedures: EntityReportType["seg_social_procedures"];
+  organisms: EntityReportType["seg_social_organisms"];
+}) {
+  const [expanded, setExpanded] = useState(false);
+
+  if (procedures.length === 0 && organisms.length === 0) return null;
+
+  return (
+    <div className="bg-white rounded-lg border">
+      <button
+        type="button"
+        onClick={() => setExpanded(!expanded)}
+        className="w-full flex items-center justify-between p-4 text-left hover:bg-gray-50 transition-colors"
+      >
+        <span className="font-semibold text-gray-700">
+          Seg. Social — Public Procedures
+          <span className="ml-2 text-sm font-normal text-gray-500">
+            ({procedures.length} procedures, {organisms.length} organisms)
+          </span>
+        </span>
+        <svg
+          className={`w-5 h-5 text-gray-400 transition-transform ${expanded ? "rotate-180" : ""}`}
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M19 9l-7 7-7-7"
+          />
+        </svg>
+      </button>
+      {expanded && (
+        <div className="border-t p-4">
+          {organisms.length > 0 && (
+            <div className="mb-4">
+              <p className="text-xs text-gray-500 uppercase tracking-wide mb-2">
+                Organisms
+              </p>
+              <div className="flex flex-wrap gap-2">
+                {organisms.map((o) => (
+                  <span
+                    key={o.id}
+                    className="px-2 py-1 bg-blue-50 text-blue-700 text-xs rounded-full"
+                  >
+                    {o.acronym || o.name} ({o.procedure_count})
+                  </span>
+                ))}
+              </div>
+            </div>
+          )}
+          <div className="space-y-2 max-h-60 overflow-y-auto">
+            {procedures.slice(0, 20).map((p, i) => (
+              <div
+                key={`${p.code}-${i}`}
+                className="p-2 bg-gray-50 rounded text-sm"
+              >
+                <div className="flex justify-between">
+                  <span className="font-medium text-gray-800 truncate max-w-[70%]">
+                    {p.title}
+                  </span>
+                  <span className="text-xs text-gray-500">
+                    {p.publication_date}
+                  </span>
+                </div>
+                <div className="flex gap-2 mt-1 text-xs text-gray-500">
+                  <span>{p.organism_acronym || p.organism_name}</span>
+                  {p.scope && <span>({p.scope})</span>}
+                  {p.career && <span>{p.career}</span>}
+                </div>
+              </div>
+            ))}
+            {procedures.length > 20 && (
+              <p className="text-xs text-gray-400 text-center">
+                Showing 20 of {procedures.length} procedures
+              </p>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
 export function EntityReport({ report }: Props) {
   const hasWarnings = report.has_insolvency || report.is_tax_debtor;
 
@@ -78,6 +170,12 @@ export function EntityReport({ report }: Props) {
             {report.company && (
               <p className="text-sm text-gray-500 mt-1">
                 {entityTypeLabel(report.company.entity_type)}
+              </p>
+            )}
+            {/* LEI inline if available */}
+            {report.lei_record && (
+              <p className="text-xs text-gray-400 mt-1 font-mono">
+                LEI: {report.lei_record.lei}
               </p>
             )}
           </div>
@@ -129,6 +227,14 @@ export function EntityReport({ report }: Props) {
         />
       </div>
 
+      {/* LEI Record */}
+      {report.lei_record && <LEICard record={report.lei_record} />}
+
+      {/* Entity Profile (IMPIC stats) */}
+      {report.entity_profile && (
+        <EntityProfileCard profile={report.entity_profile} />
+      )}
+
       {/* Iberinform */}
       {report.iberinform_content && (
         <IberinformSection content={report.iberinform_content} />
@@ -138,6 +244,12 @@ export function EntityReport({ report }: Props) {
       <ContractsList
         contracts={report.contracts}
         totalValue={report.contracts_total_value}
+      />
+
+      {/* Seg Social */}
+      <SegSocialSection
+        procedures={report.seg_social_procedures ?? []}
+        organisms={report.seg_social_organisms ?? []}
       />
     </div>
   );

--- a/frontend/src/components/LEICard.tsx
+++ b/frontend/src/components/LEICard.tsx
@@ -1,0 +1,105 @@
+import { useState } from "react";
+import type { LEIRecord } from "../types";
+
+interface Props {
+  record: LEIRecord;
+}
+
+export function LEICard({ record }: Props) {
+  const [expanded, setExpanded] = useState(false);
+
+  const isActive = record.entity_status === "ACTIVE";
+
+  return (
+    <div className="bg-white rounded-lg border p-6">
+      <div className="flex items-start justify-between">
+        <h3 className="text-lg font-semibold flex items-center gap-2">
+          LEI Record
+          <span
+            className={`px-2 py-0.5 text-xs font-bold rounded-full ${
+              isActive
+                ? "bg-green-100 text-green-700"
+                : "bg-yellow-100 text-yellow-700"
+            }`}
+          >
+            {record.entity_status || "UNKNOWN"}
+          </span>
+        </h3>
+        <span className="font-mono text-xs text-gray-400 bg-gray-50 px-2 py-1 rounded">
+          {record.lei}
+        </span>
+      </div>
+
+      <div className="mt-4 grid grid-cols-1 md:grid-cols-2 gap-4">
+        <div>
+          <p className="text-xs text-gray-500 uppercase tracking-wide">
+            Legal Name
+          </p>
+          <p className="text-sm font-medium text-gray-900 mt-1">
+            {record.legal_name}
+          </p>
+          {record.other_names.length > 0 && (
+            <p className="text-xs text-gray-500 mt-0.5">
+              Also: {record.other_names.slice(0, 3).join(", ")}
+            </p>
+          )}
+        </div>
+        <div>
+          <p className="text-xs text-gray-500 uppercase tracking-wide">
+            Registered Address
+          </p>
+          <p className="text-sm text-gray-700 mt-1">
+            {[record.legal_address, record.legal_city, record.legal_postal_code]
+              .filter(Boolean)
+              .join(", ")}
+          </p>
+        </div>
+      </div>
+
+      {/* Expandable details */}
+      <button
+        onClick={() => setExpanded(!expanded)}
+        className="mt-3 text-xs text-blue-600 hover:text-blue-800"
+      >
+        {expanded ? "Hide details" : "Show more details"}
+      </button>
+
+      {expanded && (
+        <div className="mt-3 pt-3 border-t grid grid-cols-2 md:grid-cols-3 gap-3 text-sm">
+          {record.headquarters_address && (
+            <div>
+              <p className="text-xs text-gray-500">Headquarters</p>
+              <p className="text-gray-700">
+                {[record.headquarters_address, record.headquarters_city]
+                  .filter(Boolean)
+                  .join(", ")}
+              </p>
+            </div>
+          )}
+          <div>
+            <p className="text-xs text-gray-500">Jurisdiction</p>
+            <p className="text-gray-700">{record.jurisdiction || "-"}</p>
+          </div>
+          <div>
+            <p className="text-xs text-gray-500">Registration Status</p>
+            <p className="text-gray-700">{record.registration_status || "-"}</p>
+          </div>
+          <div>
+            <p className="text-xs text-gray-500">First Registered</p>
+            <p className="text-gray-700">
+              {record.initial_registration_date || "-"}
+            </p>
+          </div>
+          <div>
+            <p className="text-xs text-gray-500">Last Updated</p>
+            <p className="text-gray-700">{record.last_update_date || "-"}</p>
+          </div>
+          <div>
+            <p className="text-xs text-gray-500">Next Renewal</p>
+            <p className="text-gray-700">{record.next_renewal_date || "-"}</p>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/SearchBar.tsx
+++ b/frontend/src/components/SearchBar.tsx
@@ -1,63 +1,155 @@
-import { useState } from "react";
+import { useState, useRef, useEffect } from "react";
+import type { NameSearchMatch } from "../types";
 
 interface Props {
-  onSearch: (nif: string) => void;
+  onSearchNif: (nif: string) => void;
+  onSearchName: (name: string) => void;
+  nameResults: NameSearchMatch[];
   loading: boolean;
+  nameLoading: boolean;
 }
 
-export function SearchBar({ onSearch, loading }: Props) {
+export function SearchBar({
+  onSearchNif,
+  onSearchName,
+  nameResults,
+  loading,
+  nameLoading,
+}: Props) {
   const [input, setInput] = useState("");
+  const [showResults, setShowResults] = useState(false);
+  const wrapperRef = useRef<HTMLDivElement>(null);
+
+  const cleaned = input.replace(/\s/g, "");
+  const isNif = /^\d{1,9}$/.test(cleaned);
+  const isValidNif = /^\d{9}$/.test(cleaned);
+  const isNameQuery = input.trim().length >= 2 && !isNif;
+
+  // Close dropdown on outside click
+  useEffect(() => {
+    const handler = (e: MouseEvent) => {
+      if (wrapperRef.current && !wrapperRef.current.contains(e.target as Node)) {
+        setShowResults(false);
+      }
+    };
+    document.addEventListener("mousedown", handler);
+    return () => document.removeEventListener("mousedown", handler);
+  }, []);
+
+  // Show results dropdown when we have name results
+  useEffect(() => {
+    if (nameResults.length > 0) setShowResults(true);
+  }, [nameResults]);
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
-    const cleaned = input.replace(/\s/g, "");
-    if (cleaned.length === 9 && /^\d+$/.test(cleaned)) {
-      onSearch(cleaned);
+    if (isValidNif) {
+      setShowResults(false);
+      onSearchNif(cleaned);
+    } else if (isNameQuery) {
+      onSearchName(input.trim());
     }
   };
 
-  const isValidNif = /^\d{9}$/.test(input.replace(/\s/g, ""));
+  const handleSelectResult = (nif: string) => {
+    setInput(nif);
+    setShowResults(false);
+    onSearchNif(nif);
+  };
 
   return (
-    <form onSubmit={handleSubmit} className="w-full max-w-2xl mx-auto">
-      <div className="flex gap-3">
-        <div className="flex-1 relative">
-          <input
-            type="text"
-            value={input}
-            onChange={(e) => setInput(e.target.value)}
-            placeholder="Enter a 9-digit NIF (e.g. 500697256)"
-            className="w-full px-4 py-3 bg-white border border-gray-300 rounded-lg text-lg
-                       focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent
-                       placeholder:text-gray-400"
-            maxLength={9}
-          />
-          {input && !isValidNif && (
-            <p className="absolute -bottom-6 left-1 text-sm text-red-500">
-              NIF must be exactly 9 digits
-            </p>
-          )}
+    <div ref={wrapperRef} className="w-full max-w-2xl mx-auto relative">
+      <form onSubmit={handleSubmit}>
+        <div className="flex gap-3">
+          <div className="flex-1 relative">
+            <input
+              type="text"
+              value={input}
+              onChange={(e) => setInput(e.target.value)}
+              placeholder="Enter a NIF (e.g. 500697256) or company name"
+              className="w-full px-4 py-3 bg-white border border-gray-300 rounded-lg text-lg
+                         focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent
+                         placeholder:text-gray-400"
+            />
+            {input && !isValidNif && isNif && (
+              <p className="absolute -bottom-6 left-1 text-sm text-gray-400">
+                NIF must be exactly 9 digits
+              </p>
+            )}
+            {isNameQuery && !nameLoading && (
+              <p className="absolute -bottom-6 left-1 text-sm text-blue-500">
+                Press Enter to search by name
+              </p>
+            )}
+          </div>
+          <button
+            type="submit"
+            disabled={(!isValidNif && !isNameQuery) || loading || nameLoading}
+            className="px-6 py-3 bg-blue-600 text-white font-medium rounded-lg
+                       hover:bg-blue-700 disabled:bg-gray-300 disabled:cursor-not-allowed
+                       transition-colors whitespace-nowrap"
+          >
+            {loading || nameLoading ? (
+              <span className="flex items-center gap-2">
+                <svg className="animate-spin h-5 w-5" viewBox="0 0 24 24">
+                  <circle
+                    className="opacity-25"
+                    cx="12"
+                    cy="12"
+                    r="10"
+                    stroke="currentColor"
+                    strokeWidth="4"
+                    fill="none"
+                  />
+                  <path
+                    className="opacity-75"
+                    fill="currentColor"
+                    d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"
+                  />
+                </svg>
+                Searching...
+              </span>
+            ) : (
+              "Search"
+            )}
+          </button>
         </div>
-        <button
-          type="submit"
-          disabled={!isValidNif || loading}
-          className="px-6 py-3 bg-blue-600 text-white font-medium rounded-lg
-                     hover:bg-blue-700 disabled:bg-gray-300 disabled:cursor-not-allowed
-                     transition-colors"
-        >
-          {loading ? (
-            <span className="flex items-center gap-2">
-              <svg className="animate-spin h-5 w-5" viewBox="0 0 24 24">
-                <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" fill="none" />
-                <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
-              </svg>
-              Searching...
-            </span>
-          ) : (
-            "Search"
-          )}
-        </button>
-      </div>
-    </form>
+      </form>
+
+      {/* Name search results dropdown */}
+      {showResults && nameResults.length > 0 && (
+        <div className="absolute z-10 mt-2 w-full bg-white border border-gray-200 rounded-lg shadow-lg max-h-80 overflow-y-auto">
+          <div className="px-4 py-2 bg-gray-50 border-b text-xs text-gray-500 font-medium">
+            {nameResults.length} matching entities — click to view report
+          </div>
+          {nameResults.map((r, i) => (
+            <button
+              key={`${r.nif}-${i}`}
+              onClick={() => handleSelectResult(r.nif)}
+              className="w-full text-left px-4 py-3 hover:bg-blue-50 border-b last:border-0 transition-colors"
+            >
+              <div className="flex items-center justify-between">
+                <div>
+                  <span className="font-medium text-gray-900">{r.name}</span>
+                  <span className="ml-2 text-sm text-gray-500">
+                    NIF {r.nif}
+                  </span>
+                </div>
+                <div className="flex items-center gap-2">
+                  {r.lei && (
+                    <span className="px-1.5 py-0.5 text-[10px] bg-purple-100 text-purple-700 rounded font-medium">
+                      LEI
+                    </span>
+                  )}
+                  <span className="px-1.5 py-0.5 text-[10px] bg-gray-100 text-gray-600 rounded">
+                    {r.source === "impic_entities" ? "IMPIC" : r.source.toUpperCase()}
+                  </span>
+                </div>
+              </div>
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
   );
 }

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -37,6 +37,64 @@ export interface DebtorRecord {
   found: boolean;
 }
 
+export interface EntityProfile {
+  nif: string;
+  name: string;
+  country: string | null;
+  country_code: string | null;
+  total_contracts: number | null;
+  times_as_supplier: number | null;
+  total_value_as_supplier: number | null;
+  times_as_entity: number | null;
+  total_value_as_entity: number | null;
+}
+
+export interface LEIRecord {
+  lei: string;
+  legal_name: string;
+  other_names: string[];
+  legal_address: string;
+  legal_city: string;
+  legal_region: string;
+  legal_country: string;
+  legal_postal_code: string;
+  headquarters_address: string;
+  headquarters_city: string;
+  headquarters_country: string;
+  registered_as: string;
+  jurisdiction: string;
+  entity_status: string;
+  entity_category: string;
+  legal_form_code: string;
+  registration_status: string;
+  initial_registration_date: string;
+  last_update_date: string;
+  next_renewal_date: string;
+}
+
+export interface SegSocialProcedure {
+  code: string;
+  title: string;
+  variant: string;
+  scope: string;
+  procedure_type: string;
+  career: string;
+  service: string;
+  publication_date: string;
+  expiration_date: string;
+  organism_id: string;
+  organism_name: string;
+  organism_acronym: string;
+  documents: { title: string; url: string }[];
+}
+
+export interface SegSocialOrganism {
+  id: string;
+  name: string;
+  acronym: string;
+  procedure_count: number;
+}
+
 export interface SourceResult {
   source: string;
   status: "ok" | "error" | "timeout" | "not_found";
@@ -57,7 +115,24 @@ export interface EntityReport {
   has_insolvency: boolean;
   debtor: DebtorRecord | null;
   is_tax_debtor: boolean;
+  entity_profile: EntityProfile | null;
+  lei_record: LEIRecord | null;
+  seg_social_procedures: SegSocialProcedure[];
+  seg_social_organisms: SegSocialOrganism[];
   iberinform_content: string | null;
   source_statuses: SourceResult[];
   queried_at: string;
+}
+
+export interface NameSearchMatch {
+  nif: string;
+  name: string;
+  source: string;
+  lei?: string;
+}
+
+export interface NameSearchResult {
+  query: string;
+  results: NameSearchMatch[];
+  total_matches: number;
 }


### PR DESCRIPTION
## Summary

- **Name search**: Type a company name in the search bar → get a dropdown of matching entities from IMPIC (110K+) and GLEIF → click one to view the full report
- **LEI Card**: Displays GLEIF LEI record with legal name, address, entity status (ACTIVE/INACTIVE), registration dates, expandable details
- **Entity Profile Card**: Shows IMPIC contract aggregation stats — total contracts, value as supplier vs. contracting entity
- **Seg Social**: Data is collected in the backend but hidden in the UI until it's connected to entity-level intelligence
- **Dev script**: `./dev.sh` starts both backend and frontend with a single command

### New files
- `frontend/src/components/EntityProfileCard.tsx` — IMPIC stats grid
- `frontend/src/components/LEICard.tsx` — LEI record with expandable details
- `dev.sh` — one-command dev setup

### Modified files
- `frontend/src/types.ts` — Added EntityProfile, LEIRecord, SegSocial*, NameSearchMatch, NameSearchResult
- `frontend/src/api/client.ts` — Added `searchByName()` 
- `frontend/src/components/SearchBar.tsx` — Auto-detects NIF vs name, shows results dropdown
- `frontend/src/components/EntityReport.tsx` — Renders LEICard, EntityProfileCard; Seg Social commented out
- `frontend/src/App.tsx` — Dual search flow (NIF direct, name with picker)

## Test plan
- [ ] `npx tsc --noEmit` passes (verified)
- [ ] `npm run build` succeeds (verified)
- [ ] NIF search still works as before (e.g. `500697256`)
- [ ] Name search shows dropdown of matching entities (e.g. "Galp")
- [ ] Clicking a name result triggers NIF search and shows full report
- [ ] LEI card shows for entities with LEI data (e.g. EDP)
- [ ] Entity Profile card shows IMPIC stats
- [ ] Seg Social section is hidden in the UI
- [ ] `./dev.sh` starts both backend and frontend

🤖 Generated with [Claude Code](https://claude.com/claude-code)