### PR TITLE
Add intelligence summary and skeleton streaming UX (v2)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -91,7 +91,7 @@ export default function App() {
 
         {report && (
           <>
-            <EntityReport report={report} />
+            <EntityReport report={report} loading={loading} />
             {!loading && (
               <ChatPanel
                 key={report.nif + report.queried_at}

--- a/frontend/src/components/EntityReport.tsx
+++ b/frontend/src/components/EntityReport.tsx
@@ -4,9 +4,12 @@ import { DebtorStatus } from "./DebtorStatus";
 import { ContractsList } from "./ContractsList";
 import { CompanyProfile } from "./CompanyProfile";
 import { AdCCard } from "./AdCCard";
+import { IntelligenceSummary } from "./IntelligenceSummary";
+import { StreamSection, SkeletonHalfCard, SkeletonCard } from "./Skeleton";
 
 interface Props {
   report: EntityReportType;
+  loading?: boolean;
 }
 
 function entityTypeLabel(type: string): string {
@@ -60,7 +63,7 @@ function SourceStatuses({ statuses }: { statuses: SourceResult[] }) {
   );
 }
 
-export function EntityReport({ report }: Props) {
+export function EntityReport({ report, loading = false }: Props) {
   const hasWarnings =
     report.has_insolvency || report.is_tax_debtor || report.has_competition_issues;
 
@@ -120,40 +123,59 @@ export function EntityReport({ report }: Props) {
         <SourceStatuses statuses={report.source_statuses} />
       </div>
 
+      {/* Intelligence Summary */}
+      <IntelligenceSummary report={report} loading={loading} />
+
       {/* Risk indicators */}
-      <div className="grid grid-cols-1 md:grid-cols-2 gap-4 animate-fade-in-up" style={{ animationDelay: "80ms" }}>
-        <InsolvencyBadge
-          proceedings={report.insolvency_proceedings}
-          hasInsolvency={report.has_insolvency}
-        />
-        <DebtorStatus
-          debtor={report.debtor}
-          isTaxDebtor={report.is_tax_debtor}
-        />
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <StreamSection
+          source="citius"
+          report={report}
+          skeleton={<SkeletonHalfCard />}
+        >
+          <InsolvencyBadge
+            proceedings={report.insolvency_proceedings}
+            hasInsolvency={report.has_insolvency}
+          />
+        </StreamSection>
+        <StreamSection
+          source="devedores"
+          report={report}
+          skeleton={<SkeletonHalfCard />}
+        >
+          <DebtorStatus
+            debtor={report.debtor}
+            isTaxDebtor={report.is_tax_debtor}
+          />
+        </StreamSection>
       </div>
 
       {/* Company Profile — unified identity + stats from LEI, IMPIC, ptdata */}
-      <div className="animate-fade-in-up" style={{ animationDelay: "160ms" }}>
+      <StreamSection
+        source={["entities", "gleif"]}
+        report={report}
+        skeleton={<SkeletonCard lines={5} />}
+      >
         <CompanyProfile report={report} />
-      </div>
+      </StreamSection>
 
       {/* Competition Authority (AdC) */}
-      <div className="animate-fade-in-up" style={{ animationDelay: "240ms" }}>
       <AdCCard
         processes={report.adc_processes ?? []}
         hasCompetitionIssues={report.has_competition_issues ?? false}
       />
-      </div>
 
       {/* Contracts */}
-      <div className="animate-fade-in-up" style={{ animationDelay: "320ms" }}>
-      <ContractsList
-        contracts={report.contracts}
-        totalValue={report.contracts_total_value}
-      />
-      </div>
-
-      {/* Seg Social — hidden until connected to entity-level intelligence */}
+      <StreamSection
+        source="contracts"
+        report={report}
+        skeleton={<SkeletonCard lines={6} />}
+      >
+        <ContractsList
+          contracts={report.contracts}
+          totalValue={report.contracts_total_value}
+        />
+      </StreamSection>
     </div>
   );
 }

--- a/frontend/src/components/IntelligenceSummary.tsx
+++ b/frontend/src/components/IntelligenceSummary.tsx
@@ -1,0 +1,141 @@
+import type { EntityReport } from "../types";
+import { formatEUR } from "../format";
+
+interface Props {
+  report: EntityReport;
+  loading: boolean;
+}
+
+type FindingType = "risk" | "clear" | "info";
+
+interface Finding {
+  type: FindingType;
+  label: string;
+}
+
+function isSourceDone(report: EntityReport, sourceName: string): boolean {
+  const source = report.source_statuses.find((s) => s.source === sourceName);
+  return source != null && source.status !== "pending";
+}
+
+function buildFindings(report: EntityReport): Finding[] {
+  const findings: Finding[] = [];
+
+  // Risk findings
+  if (report.has_insolvency) {
+    const count = report.insolvency_proceedings.length;
+    findings.push({
+      type: "risk",
+      label: `Insolvency: ${count} proceeding${count !== 1 ? "s" : ""} found`,
+    });
+  }
+
+  if (report.is_tax_debtor) {
+    const bracket = report.debtor?.debt_bracket_label;
+    findings.push({
+      type: "risk",
+      label: bracket ? `Tax debtor (${bracket})` : "Tax debtor",
+    });
+  }
+
+  const sanctions = (report.adc_processes ?? []).filter(
+    (p) => p.final_decision === "Condenatória"
+  ).length;
+  if (sanctions > 0) {
+    findings.push({
+      type: "risk",
+      label: `Competition Authority: ${sanctions} sanction${sanctions !== 1 ? "s" : ""}`,
+    });
+  }
+
+  // Clear findings
+  if (!report.has_insolvency && isSourceDone(report, "citius")) {
+    findings.push({ type: "clear", label: "No insolvency proceedings" });
+  }
+
+  if (!report.is_tax_debtor && isSourceDone(report, "devedores")) {
+    findings.push({ type: "clear", label: "Not a tax debtor" });
+  }
+
+  const allDone = report.source_statuses.every((s) => s.status !== "pending");
+  if (!report.has_competition_issues && allDone) {
+    findings.push({ type: "clear", label: "No competition issues" });
+  }
+
+  if (report.lei_record?.entity_status === "ACTIVE") {
+    findings.push({ type: "clear", label: "Active LEI" });
+  }
+
+  // Info findings
+  if (isSourceDone(report, "contracts") && report.contracts.length > 0) {
+    findings.push({
+      type: "info",
+      label: `${report.contracts.length} contract${report.contracts.length !== 1 ? "s" : ""} (${formatEUR(report.contracts_total_value)})`,
+    });
+  }
+
+  return findings;
+}
+
+const DOT_COLORS: Record<FindingType, string> = {
+  risk: "bg-red-500",
+  clear: "bg-green-500",
+  info: "bg-stone-400",
+};
+
+const TEXT_COLORS: Record<FindingType, string> = {
+  risk: "text-red-700",
+  clear: "text-green-700",
+  info: "text-stone-600",
+};
+
+export function IntelligenceSummary({ report, loading }: Props) {
+  const findings = buildFindings(report);
+  const pendingCount = report.source_statuses.filter(
+    (s) => s.status === "pending"
+  ).length;
+  const allDone = pendingCount === 0;
+  const risks = findings.filter((f) => f.type === "risk");
+
+  if (findings.length === 0 && !loading) return null;
+
+  return (
+    <section aria-label="Quick assessment" className="bg-white rounded-lg border border-stone-200 p-4 sm:p-6 animate-fade-in">
+      <div className="flex items-center justify-between mb-3">
+        <h3 className="text-sm font-semibold text-stone-500 uppercase tracking-wide">
+          Quick Assessment
+        </h3>
+        {loading && pendingCount > 0 && (
+          <span className="text-xs text-stone-400">
+            {pendingCount} source{pendingCount !== 1 ? "s" : ""} loading...
+          </span>
+        )}
+        {allDone && risks.length === 0 && (
+          <span className="px-2.5 py-0.5 text-xs font-bold bg-green-100 text-green-700 rounded-full">
+            NO RISKS DETECTED
+          </span>
+        )}
+        {allDone && risks.length > 0 && (
+          <span className="px-2.5 py-0.5 text-xs font-bold bg-red-100 text-red-700 rounded-full">
+            {risks.length} RISK{risks.length !== 1 ? "S" : ""} FOUND
+          </span>
+        )}
+      </div>
+
+      <div className="flex flex-wrap gap-2">
+        {findings.map((f, i) => (
+          <div
+            key={f.label}
+            className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full bg-stone-50 border border-stone-100 text-sm animate-fade-in"
+            style={{ animationDelay: `${i * 60}ms` }}
+          >
+            <span
+              className={`w-1.5 h-1.5 rounded-full shrink-0 ${DOT_COLORS[f.type]}`}
+            />
+            <span className={TEXT_COLORS[f.type]}>{f.label}</span>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/components/Skeleton.tsx
+++ b/frontend/src/components/Skeleton.tsx
@@ -1,0 +1,80 @@
+import type { ReactNode } from "react";
+import type { EntityReport } from "../types";
+
+interface SkeletonBarProps {
+  className?: string;
+}
+
+export function SkeletonBar({ className = "" }: SkeletonBarProps) {
+  return (
+    <div
+      className={`animate-pulse bg-stone-200 rounded ${className}`}
+      aria-hidden="true"
+    />
+  );
+}
+
+interface SkeletonCardProps {
+  lines?: number;
+  className?: string;
+}
+
+export function SkeletonCard({ lines = 3, className = "" }: SkeletonCardProps) {
+  return (
+    <div
+      className={`bg-white rounded-lg border border-stone-200 p-4 sm:p-6 ${className}`}
+      aria-hidden="true"
+    >
+      <SkeletonBar className="h-5 w-40 mb-4" />
+      {Array.from({ length: lines }, (_, i) => (
+        <SkeletonBar
+          key={i}
+          className={`h-3.5 mb-2.5 last:mb-0 ${i === lines - 1 ? "w-2/3" : "w-full"}`}
+        />
+      ))}
+    </div>
+  );
+}
+
+interface SkeletonHalfCardProps {
+  className?: string;
+}
+
+export function SkeletonHalfCard({ className = "" }: SkeletonHalfCardProps) {
+  return (
+    <div
+      className={`bg-white rounded-lg border border-stone-200 p-4 sm:p-6 ${className}`}
+      aria-hidden="true"
+    >
+      <SkeletonBar className="h-5 w-32 mb-3" />
+      <SkeletonBar className="h-3.5 w-full mb-2" />
+      <SkeletonBar className="h-3.5 w-1/2" />
+    </div>
+  );
+}
+
+interface StreamSectionProps {
+  source: string | string[];
+  report: EntityReport;
+  skeleton: ReactNode;
+  children: ReactNode;
+}
+
+export function StreamSection({
+  source,
+  report,
+  skeleton,
+  children,
+}: StreamSectionProps) {
+  const sources = Array.isArray(source) ? source : [source];
+  const allPending = sources.every((s) => {
+    const found = report.source_statuses.find((r) => r.source === s);
+    return !found || found.status === "pending";
+  });
+
+  if (allPending) {
+    return <>{skeleton}</>;
+  }
+
+  return <div className="animate-fade-in">{children}</div>;
+}


### PR DESCRIPTION
## Summary

Two UX improvements to the entity report, implemented with the full review cycle (dev-team-full).

### 1. Intelligence Summary ("Quick Assessment")
Color-coded verdict at the top of every report:
- **Red pills** — risks: insolvency proceedings (count), tax debtor (bracket), Competition Authority sanctions (count)
- **Green pills** — clear: no insolvency, not a debtor, no competition issues, active LEI
- **Gray pills** — info: contract count and total value
- Updates live during streaming — findings appear as each source completes
- "NO RISKS DETECTED" or "N RISKS FOUND" badge when all sources finish
- Semantic `<section aria-label="Quick assessment">` for screen reader navigation

### 2. Skeleton Streaming UX
- `StreamSection` wrapper: renders pulsing skeleton card while source is "pending", fades in real content via `animate-fade-in` when done
- `SkeletonCard` / `SkeletonHalfCard` match real section dimensions — stable layout from first frame
- All skeleton elements have `aria-hidden="true"`
- Insolvency, debtor, company profile, and contracts sections all wrapped
- AdCCard left unwrapped (populated via cross-reference after all sources)

### Review Cycle Results

| Review | Result |
|--------|--------|
| **QA** | 10/10 acceptance criteria pass. No bugs. TypeScript + build clean. |
| **UX** | 2 medium issues found → fixed in improvement round: added `<section aria-label>`, expanded "AdC" to "Competition Authority" |
| **Architecture** | Clean structure. Pure `buildFindings` function. Proper separation of concerns. |

**Classification: Ship** after 1 improvement round.

### New files
- `frontend/src/components/IntelligenceSummary.tsx`
- `frontend/src/components/Skeleton.tsx`

### Modified files
- `frontend/src/components/EntityReport.tsx` — wraps sections in `StreamSection`, adds `IntelligenceSummary`
- `frontend/src/App.tsx` — passes `loading` prop

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npm run build` — clean
- [ ] Search EDP (500697256) — skeletons appear, data fades in progressively
- [ ] Summary shows risks for sanctioned companies, "NO RISKS DETECTED" for clean ones
- [ ] Layout stable during streaming — no vertical jumps
- [ ] Screen reader: `<section>` landmark navigable, skeletons hidden

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a "Quick Assessment" section displaying intelligent findings about entities, including risk indicators, clear statuses, and contract summaries.
  * Enhanced loading experience with skeleton screens that appear while data streams in for each report section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->