### PR TITLE
Automate develop → main release PR

### DIFF
--- a/.github/workflows/release-pr-open.yml
+++ b/.github/workflows/release-pr-open.yml
@@ -1,0 +1,136 @@
+# Opens a fresh, empty release PR (develop → main) after every release.
+#
+# Triggered by two events:
+#   1. A PR from `develop` to `main` closes — regardless of merged/not,
+#      we need to make sure there's always exactly one open release PR
+#      (or zero, briefly, before this job runs).
+#   2. Manual dispatch via the Actions tab, for the first-ever release
+#      or to recover from accidental PR deletion.
+#
+# The PR body is the same skeleton the sync workflow expects: it has the
+# two marker pairs (`RELEASE_PR:PRS_*` and `RELEASE_PR:CLOSES_*`) empty
+# and ready to be filled as new PRs merge to develop.
+name: Release PR open
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  pull-requests: write
+  contents: read
+
+jobs:
+  open:
+    # Only react to PRs whose head is `develop` — don't open a new
+    # release PR in response to, say, a hotfix merged directly to main.
+    if: >-
+      github.event_name == 'workflow_dispatch'
+      || github.event.pull_request.head.ref == 'develop'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Open fresh release PR
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const { owner, repo } = context.repo;
+
+            // If a release PR is already open, we're done. This makes the
+            // workflow safely re-runnable and idempotent.
+            const { data: openPrs } = await github.rest.pulls.list({
+              owner,
+              repo,
+              state: 'open',
+              base: 'main',
+              head: `${owner}:develop`,
+              per_page: 5,
+            });
+            if (openPrs.length > 0) {
+              core.info(`Release PR #${openPrs[0].number} is already open — nothing to do.`);
+              return;
+            }
+
+            // Make sure develop is actually ahead of main — otherwise
+            // `pulls.create` fails with "No commits between main and develop".
+            const { data: compare } = await github.rest.repos.compareCommits({
+              owner,
+              repo,
+              base: 'main',
+              head: 'develop',
+            });
+            if (compare.ahead_by === 0) {
+              core.info('develop has no commits ahead of main — skipping. '
+                + 'The next merge to develop will trigger the next release.');
+              return;
+            }
+
+            const body = [
+              '## 🚀 Release candidate',
+              '',
+              'This is the long-running **release PR** that accumulates every '
+              + 'change merged to `develop`. It stays open until an explicit '
+              + 'release and is updated automatically whenever a PR is merged '
+              + 'into `develop` — see the automation in '
+              + '`.github/workflows/release-pr-sync.yml`.',
+              '',
+              '**How to release**: merge this PR into `main`. The automation '
+              + 'will then open a fresh empty release PR for the next cycle.',
+              '',
+              '---',
+              '',
+              '## Closes',
+              '',
+              '<!-- RELEASE_PR:CLOSES_START -->',
+              '_No issues closed yet._',
+              '<!-- RELEASE_PR:CLOSES_END -->',
+              '',
+              '## Included PRs',
+              '',
+              '<!-- RELEASE_PR:PRS_START -->',
+              '_No PRs merged to develop in this cycle yet._',
+              '<!-- RELEASE_PR:PRS_END -->',
+              '',
+              '## Highlights',
+              '',
+              '_Fill in as PRs land — the automation only touches the sections '
+              + 'between the `RELEASE_PR:*` markers._',
+              '',
+              '## Verification before release',
+              '',
+              '- [ ] Backend: `ruff check backend/src` clean',
+              '- [ ] Frontend: `npm run build` + `tsc --noEmit` clean',
+              '- [ ] Smoke: search EDP (500697256) returns all sources `ok`',
+              '- [ ] CodeRabbit re-review on the final diff is green',
+              '',
+              '---',
+              '',
+              '<sub>Automated sections (between `RELEASE_PR:*` markers) are '
+              + 'rewritten by `release-pr-sync.yml` every time a PR merges to '
+              + '`develop`. Edit narrative sections freely — they\'re preserved '
+              + 'across updates.</sub>',
+            ].join('\n');
+
+            const { data: created } = await github.rest.pulls.create({
+              owner,
+              repo,
+              base: 'main',
+              head: 'develop',
+              title: '🚀 Release: develop → main',
+              body,
+            });
+            core.info(`Opened release PR #${created.number}.`);
+
+            // Best-effort label — no-op if the label doesn't exist in the repo.
+            try {
+              await github.rest.issues.addLabels({
+                owner,
+                repo,
+                issue_number: created.number,
+                labels: ['release'],
+              });
+            } catch (e) {
+              core.info(`Skipped adding 'release' label: ${e.message}`);
+            }

--- a/.github/workflows/release-pr-sync.yml
+++ b/.github/workflows/release-pr-sync.yml
@@ -1,0 +1,223 @@
+# Keeps the long-running release PR (develop → main) in sync with
+# everything that has shipped to develop since the last release.
+#
+# How it works
+# ------------
+# * Trigger: a PR closed against `develop`. If it wasn't actually merged,
+#   we exit early.
+# * Find the open release PR: the single PR with `base=main, head=develop`.
+#   If none exists, we log and exit (the post-release workflow will open
+#   a fresh one — see `release-pr-open.yml`).
+# * Rewrite the two automated sections in the release PR body:
+#     - `RELEASE_PR:PRS_START / PRS_END`     — bullet list of merged PRs
+#     - `RELEASE_PR:CLOSES_START / CLOSES_END` — "Closes #…" line linking
+#       every issue referenced by a merged PR, deduped and sorted.
+#   Everything outside those markers is preserved verbatim, so a human
+#   can still hand-edit the highlights / checklist / narrative.
+# * Issue tracking: every referenced issue gets a comment noting it was
+#   rolled into the release PR. This gives maintainers a trail without
+#   prematurely closing the issue (the issue closes when the release
+#   PR merges into main, via GitHub's native "Closes #N" handling).
+#
+# Permissions rationale
+# ---------------------
+# `pull-requests: write` is needed to update the release PR body.
+# `issues: write` is needed to post the tracking comment on each issue.
+# No secrets leave the org — everything uses the default GITHUB_TOKEN.
+name: Release PR sync
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [develop]
+
+permissions:
+  pull-requests: write
+  issues: write
+  contents: read
+
+jobs:
+  sync:
+    # Only run on actual merges, not on closed-without-merging. Without
+    # this gate, closing a PR that was never merged would still rewrite
+    # the release PR body.
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - name: Update release PR
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const mergedPr = context.payload.pull_request;
+            const { owner, repo } = context.repo;
+
+            // --- 1. Find the single open release PR (develop → main) ---
+            const { data: openPrs } = await github.rest.pulls.list({
+              owner,
+              repo,
+              state: 'open',
+              base: 'main',
+              head: `${owner}:develop`,
+              per_page: 10,
+            });
+            if (openPrs.length === 0) {
+              core.info('No open release PR found — skipping sync. '
+                + 'Run release-pr-open.yml or create one manually.');
+              return;
+            }
+            if (openPrs.length > 1) {
+              core.warning(`Found ${openPrs.length} open release PRs; `
+                + 'updating the most recent one only.');
+            }
+            const releasePr = openPrs[0];
+            core.info(`Updating release PR #${releasePr.number}`);
+
+            // --- 2. Extract issue references from the merged PR body ---
+            // Matches the GitHub-native keywords (closes/fixes/resolves) and
+            // also bare "#123" references in a "Closes" line, so either
+            // "Closes #12" or "Closes #8, #9, #10" both work.
+            const body = mergedPr.body || '';
+            const issueRefs = new Set();
+            // Keyword + #N (one per match)
+            const kwRe = /\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\b[^\n]*?#(\d+)/gi;
+            for (const m of body.matchAll(kwRe)) {
+              issueRefs.add(Number(m[1]));
+            }
+            // Also pick up "Closes #8, #9, #10." style lists — the regex above
+            // only catches the first # after the keyword, so sweep for trailing
+            // comma-separated #N's on any line starting with a closing keyword.
+            for (const line of body.split('\n')) {
+              if (!/^\s*(closes?|fix(?:es)?|resolves?)\b/i.test(line)) continue;
+              for (const m of line.matchAll(/#(\d+)/g)) {
+                issueRefs.add(Number(m[1]));
+              }
+            }
+            // Drop the merged PR's own number if it somehow landed in the set
+            // (rare, but harmless to guard).
+            issueRefs.delete(mergedPr.number);
+            core.info(`Merged PR #${mergedPr.number} references issues: `
+              + `[${[...issueRefs].sort((a, b) => a - b).join(', ') || 'none'}]`);
+
+            // --- 3. Parse existing release PR body into segments ---
+            // Preserve everything outside the automation markers, so human
+            // edits to the highlights / checklist survive each sync.
+            const PR_START  = '<!-- RELEASE_PR:PRS_START -->';
+            const PR_END    = '<!-- RELEASE_PR:PRS_END -->';
+            const CL_START  = '<!-- RELEASE_PR:CLOSES_START -->';
+            const CL_END    = '<!-- RELEASE_PR:CLOSES_END -->';
+
+            function replaceSection(text, startTag, endTag, newInner) {
+              const startIdx = text.indexOf(startTag);
+              const endIdx = text.indexOf(endTag);
+              if (startIdx === -1 || endIdx === -1 || endIdx < startIdx) {
+                // Markers missing — append them rather than silently dropping
+                // the update. Maintainers can move them later if needed.
+                return text
+                  + `\n\n${startTag}\n${newInner}\n${endTag}\n`;
+              }
+              const before = text.slice(0, startIdx + startTag.length);
+              const after = text.slice(endIdx);
+              return `${before}\n${newInner}\n${after}`;
+            }
+
+            const currentBody = releasePr.body || '';
+
+            // --- 4. Extract + extend the list of included PRs ---
+            const prSection = (() => {
+              const s = currentBody.indexOf(PR_START);
+              const e = currentBody.indexOf(PR_END);
+              if (s === -1 || e === -1) return '';
+              return currentBody.slice(s + PR_START.length, e);
+            })();
+
+            // Preserve existing entries, de-dup by PR number. The existing
+            // entries may carry human-edited notes, so we match on "#N "
+            // word-boundary rather than regenerating them.
+            const existingPrNumbers = new Set();
+            const existingLines = prSection
+              .split('\n')
+              .map((l) => l.trim())
+              .filter((l) => l.startsWith('- '));
+            for (const line of existingLines) {
+              const m = line.match(/#(\d+)/);
+              if (m) existingPrNumbers.add(Number(m[1]));
+            }
+            let newPrLines = [...existingLines];
+            if (!existingPrNumbers.has(mergedPr.number)) {
+              const title = (mergedPr.title || '').replace(/\s+/g, ' ').trim();
+              newPrLines.push(`- #${mergedPr.number} — ${title}`);
+            }
+            // Sort by PR number ascending so the list reads chronologically.
+            newPrLines.sort((a, b) => {
+              const na = Number((a.match(/#(\d+)/) || [0, 0])[1]);
+              const nb = Number((b.match(/#(\d+)/) || [0, 0])[1]);
+              return na - nb;
+            });
+
+            // --- 5. Extract + extend the "Closes" list ---
+            const closesSection = (() => {
+              const s = currentBody.indexOf(CL_START);
+              const e = currentBody.indexOf(CL_END);
+              if (s === -1 || e === -1) return '';
+              return currentBody.slice(s + CL_START.length, e);
+            })();
+            const existingIssues = new Set();
+            for (const m of closesSection.matchAll(/#(\d+)/g)) {
+              existingIssues.add(Number(m[1]));
+            }
+            for (const n of issueRefs) existingIssues.add(n);
+            const sortedIssues = [...existingIssues].sort((a, b) => a - b);
+            const closesLine = sortedIssues.length
+              ? `Closes ${sortedIssues.map((n) => '#' + n).join(', ')}.`
+              : '_No issues closed yet._';
+
+            // --- 6. Splice new sections into the body and save ---
+            let newBody = replaceSection(
+              currentBody,
+              PR_START,
+              PR_END,
+              newPrLines.join('\n'),
+            );
+            newBody = replaceSection(newBody, CL_START, CL_END, closesLine);
+
+            if (newBody === currentBody) {
+              core.info('Release PR body unchanged — nothing to update.');
+              return;
+            }
+
+            await github.rest.pulls.update({
+              owner,
+              repo,
+              pull_number: releasePr.number,
+              body: newBody,
+            });
+            core.info(`Updated release PR #${releasePr.number}.`);
+
+            // --- 7. Breadcrumb each newly-added issue so maintainers know
+            //        it's tracked in the release PR. Skip issues that
+            //        already appeared in the release body (re-runs on the
+            //        same PR merge won't re-spam comments).
+            const newlyAddedIssues = [...issueRefs].filter(
+              (n) => !closesSection.includes(`#${n}`)
+                  && !closesSection.includes(`#${n},`)
+                  && !closesSection.includes(`#${n}.`),
+            );
+            for (const issueNumber of newlyAddedIssues) {
+              try {
+                await github.rest.issues.createComment({
+                  owner,
+                  repo,
+                  issue_number: issueNumber,
+                  body:
+                    `🚀 Tracked in the current release PR `
+                    + `#${releasePr.number} via #${mergedPr.number}. `
+                    + `This issue will close automatically when the release `
+                    + `PR merges to \`main\`.`,
+                });
+              } catch (e) {
+                // Issue may be locked, deleted, or in a different repo via
+                // cross-ref — best-effort, don't fail the whole job.
+                core.warning(`Could not comment on issue #${issueNumber}: ${e.message}`);
+              }
+            }


### PR DESCRIPTION
## Summary

Two new GitHub Actions workflows that keep the long-running release PR (#30) in sync with `develop`:

- **`release-pr-sync.yml`** — on every merge to `develop`, rewrites PR #30's description to add the merged PR to the "Included PRs" list and aggregate all `Closes #N` references into a single deduped line. Preserves the narrative sections (highlights, checklist, verification) outside the `RELEASE_PR:*` markers so hand edits survive.
- **`release-pr-open.yml`** — after PR #30 merges to `main`, automatically opens a fresh empty release PR so there's always exactly one open release candidate. Also exposes a manual trigger for recovery.

## Testing

- Both YAMLs parse cleanly with `yaml.safe_load`
- Marker-based splicing preserves body content outside the two `RELEASE_PR:*` regions
- Sync is idempotent — re-running on the same PR merge won't duplicate entries or re-spam issue comments

## Test plan

- [ ] Merge this PR to develop — the sync workflow will fire and add PR #31 to PR #30's "Included PRs" list
- [ ] Verify the "Closes" line on PR #30 doesn't regress (this PR doesn't close any issue)
- [ ] When ready to release, merge PR #30 to main; confirm the post-release workflow opens a new empty release PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)