### PR TITLE
Fix defaults + hide Seg Social until people-based match lands

### DIFF
--- a/backend/src/cusco/main.py
+++ b/backend/src/cusco/main.py
@@ -273,6 +273,40 @@ async def _enrich_adc(report: EntityReport) -> None:
         logger.warning(f"AdC name cross-reference failed: {e}")
 
 
+async def _enrich_seg_social(report: EntityReport) -> None:
+    """Filter Seg Social procedures by the resolved company name.
+
+    `SegSocialSource.search_by_nif` intentionally returns empty because
+    the API has no NIF filter; actual matching happens here once
+    `entities`/`gleif`/`ptdata` have supplied a name. For private
+    companies this silently resolves to zero matches — the card
+    self-hides — while public-sector entities get their procedures.
+    """
+    if report.seg_social_procedures:
+        return
+
+    company_name = None
+    if report.company and report.company.name:
+        company_name = report.company.name
+    elif report.entity_profile and report.entity_profile.name:
+        company_name = report.entity_profile.name
+    elif report.lei_record and report.lei_record.legal_name:
+        company_name = report.lei_record.legal_name
+
+    if not company_name:
+        return
+
+    try:
+        data = await seg_social_source.search_by_company_name(company_name)
+        procedures = data.get("seg_social_procedures") or []
+        organisms = data.get("seg_social_organisms") or []
+        if procedures or organisms:
+            report.seg_social_procedures = procedures
+            report.seg_social_organisms = organisms
+    except Exception as e:  # noqa: BLE001 - enrichment is best-effort
+        logger.warning(f"Seg Social name enrichment failed: {e}")
+
+
 async def _enrich_corporate_group(report: EntityReport) -> None:
     """Fill `corporate_group` from GLEIF parent/child relationships.
 
@@ -350,6 +384,10 @@ async def search_entity(
     # AdC cross-reference by company name
     await _enrich_adc(report)
 
+    # Seg Social cross-reference by company name (seg_social.search_by_nif
+    # returns empty; matching happens here once the name is resolved).
+    await _enrich_seg_social(report)
+
     # Corporate group via GLEIF parent/children
     await _enrich_corporate_group(report)
 
@@ -381,6 +419,11 @@ async def search_entity_stream(
             "gleif": gleif_source.search_by_nif(nif),
             "seg_social": seg_social_source.search_by_nif(nif),
             "iberinform": iberinform_source.search_by_nif(nif),
+            # Must mirror the non-stream task list — omitting AdC here
+            # left its status stuck on `pending` for every streamed
+            # search, because nothing ever completed the task that
+            # would flip the status.
+            "adc": adc_source.search_by_nif(nif),
             "prr": prr_source.search_by_nif(nif),
             "pt2030": pt2030_source.search_by_nif(nif),
         }
@@ -410,6 +453,10 @@ async def search_entity_stream(
 
         # AdC cross-reference after all sources complete
         await _enrich_adc(report)
+
+        # Seg Social cross-reference by company name (see _enrich_seg_social
+        # for why search_by_nif returns empty).
+        await _enrich_seg_social(report)
 
         # Corporate group via GLEIF parent/children
         await _enrich_corporate_group(report)

--- a/backend/src/cusco/main.py
+++ b/backend/src/cusco/main.py
@@ -273,40 +273,6 @@ async def _enrich_adc(report: EntityReport) -> None:
         logger.warning(f"AdC name cross-reference failed: {e}")
 
 
-async def _enrich_seg_social(report: EntityReport) -> None:
-    """Filter Seg Social procedures by the resolved company name.
-
-    `SegSocialSource.search_by_nif` intentionally returns empty because
-    the API has no NIF filter; actual matching happens here once
-    `entities`/`gleif`/`ptdata` have supplied a name. For private
-    companies this silently resolves to zero matches — the card
-    self-hides — while public-sector entities get their procedures.
-    """
-    if report.seg_social_procedures:
-        return
-
-    company_name = None
-    if report.company and report.company.name:
-        company_name = report.company.name
-    elif report.entity_profile and report.entity_profile.name:
-        company_name = report.entity_profile.name
-    elif report.lei_record and report.lei_record.legal_name:
-        company_name = report.lei_record.legal_name
-
-    if not company_name:
-        return
-
-    try:
-        data = await seg_social_source.search_by_company_name(company_name)
-        procedures = data.get("seg_social_procedures") or []
-        organisms = data.get("seg_social_organisms") or []
-        if procedures or organisms:
-            report.seg_social_procedures = procedures
-            report.seg_social_organisms = organisms
-    except Exception as e:  # noqa: BLE001 - enrichment is best-effort
-        logger.warning(f"Seg Social name enrichment failed: {e}")
-
-
 async def _enrich_corporate_group(report: EntityReport) -> None:
     """Fill `corporate_group` from GLEIF parent/child relationships.
 
@@ -384,10 +350,6 @@ async def search_entity(
     # AdC cross-reference by company name
     await _enrich_adc(report)
 
-    # Seg Social cross-reference by company name (seg_social.search_by_nif
-    # returns empty; matching happens here once the name is resolved).
-    await _enrich_seg_social(report)
-
     # Corporate group via GLEIF parent/children
     await _enrich_corporate_group(report)
 
@@ -453,10 +415,6 @@ async def search_entity_stream(
 
         # AdC cross-reference after all sources complete
         await _enrich_adc(report)
-
-        # Seg Social cross-reference by company name (see _enrich_seg_social
-        # for why search_by_nif returns empty).
-        await _enrich_seg_social(report)
 
         # Corporate group via GLEIF parent/children
         await _enrich_corporate_group(report)

--- a/backend/src/cusco/sources/seg_social.py
+++ b/backend/src/cusco/sources/seg_social.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 import logging
 from typing import Any
 
-from ..models import SegSocialProcedure, SegSocialOrganism
+from ..models import SegSocialProcedure
 from .base import DataSource
 
 logger = logging.getLogger(__name__)
@@ -70,94 +70,21 @@ class SegSocialSource(DataSource):
             return []
 
     async def search_by_nif(self, nif: str) -> dict[str, Any]:
-        """Seg Social has no NIF filter — return empty and let
-        `_enrich_seg_social` in main.py resolve matches by company name.
+        """Return empty. There is no NIF-level filter on the Seg Social API,
+        and the correct semantic match is PEOPLE-based — cross-referencing
+        named officers/directors from the company's report (Iberinform,
+        corporate-group members) against the candidates / jury members
+        listed in each procedure's PDF attachments.
 
-        Previously this returned EVERY procedure from the API for every
-        NIF search, because the loop `matching.append(raw)` had no guard.
-        The card on the frontend then displayed ~200 unrelated
-        procedures for every company — loudly wrong for private
-        companies, misleading for public ones.
-
-        Returning empty here (instead of reusing `search_by_name`
-        blindly with the NIF) keeps the source's status reporting
-        intact without leaking unfiltered data into the report."""
+        The PDF-extraction + NER pipeline needed for that match is tracked
+        as a follow-up issue. Until it lands, this source returns nothing
+        so the UI doesn't show unrelated procedures as if they were
+        connected to the searched company. `_fetch_procedures` is kept
+        for the future implementation and for the `search_by_name`
+        admin path."""
         return {
             "seg_social_procedures": [],
             "seg_social_organisms": [],
-        }
-
-    async def search_by_company_name(
-        self, name: str, acronym: str | None = None
-    ) -> dict[str, Any]:
-        """Filter procedures whose organism name/acronym matches the company.
-
-        Called as a name-based enrichment step AFTER entities/gleif/ptdata
-        have filled in `report.company.name`. Matching is intentionally
-        strict — substring match on the FULL name (not a token), plus
-        optional acronym match — because Seg Social organisms are
-        public-sector entities (ministries, universities, municipal
-        councils) and we don't want e.g. searching "EDP" to accidentally
-        match "Escola Dr. Pedro..." via a shared prefix.
-        """
-        query = (name or "").strip().lower()
-        acr = (acronym or "").strip().lower() if acronym else ""
-        if len(query) < 3:
-            # Short names produce too many false positives in substring
-            # matching; require a real name to avoid leaking noise.
-            return {"seg_social_procedures": [], "seg_social_organisms": []}
-
-        try:
-            all_procs = await self._fetch_procedures()
-        except Exception as e:  # noqa: BLE001 - enrichment is best-effort
-            logger.warning(f"Seg Social fetch failed: {e}")
-            return {"seg_social_procedures": [], "seg_social_organisms": []}
-
-        # Also fetch mobility procedures — same endpoint, different type
-        try:
-            mobility_procs = await self._fetch_procedures("MOBILITY")
-            all_procs.extend(mobility_procs)
-        except Exception:  # noqa: BLE001 - MOBILITY endpoint may not exist
-            pass
-
-        matching: list[dict] = []
-        for raw in all_procs:
-            organism = raw.get("organism", {}) or {}
-            org_name = str(organism.get("name", "")).lower()
-            org_acronym = str(organism.get("acronym", "")).lower()
-
-            # Match on full-name substring (company name contained in
-            # organism name, or vice-versa — public entities sometimes
-            # have a longer formal name than the user's search). Acronym
-            # match requires EXACT equality to avoid matching 3-letter
-            # fragments inside unrelated strings.
-            name_match = (
-                (query in org_name and org_name)
-                or (org_name and org_name in query)
-            )
-            acronym_match = bool(acr) and acr == org_acronym
-            if name_match or acronym_match:
-                matching.append(raw)
-
-        procedures = [self._to_procedure(p) for p in matching]
-
-        # Group by organism — same logic as before, but only for the
-        # filtered subset so orphaned organism badges don't leak.
-        organisms: dict[str, SegSocialOrganism] = {}
-        for proc in procedures:
-            if proc.organism_name and proc.organism_id:
-                if proc.organism_id not in organisms:
-                    organisms[proc.organism_id] = SegSocialOrganism(
-                        id=proc.organism_id,
-                        name=proc.organism_name,
-                        acronym=proc.organism_acronym,
-                        procedure_count=0,
-                    )
-                organisms[proc.organism_id].procedure_count += 1
-
-        return {
-            "seg_social_procedures": procedures,
-            "seg_social_organisms": list(organisms.values()),
         }
 
     async def search_by_name(self, name: str) -> dict[str, Any]:

--- a/backend/src/cusco/sources/seg_social.py
+++ b/backend/src/cusco/sources/seg_social.py
@@ -36,8 +36,12 @@ class SegSocialSource(DataSource):
     async def _fetch_procedures(self, proc_type: str = "PROCEDURE") -> list[dict]:
         """Fetch all procedures of a given type."""
         async with self._client() as client:
-            # First load the HTML page to get session cookie (fvcc)
-            page_resp = await client.get(
+            # First load the HTML page purely to pick up the session
+            # cookie (fvcc) that the JSON endpoint requires. We throw
+            # the response away — don't assign to a named variable
+            # (ruff F841) and don't `raise_for_status` since a 403/500
+            # still sets the cookie we need.
+            await client.get(
                 PAGE_URL,
                 headers={
                     "Accept": "text/html",
@@ -48,7 +52,6 @@ class SegSocialSource(DataSource):
                     ),
                 },
             )
-            # Don't raise — we just need the cookie
 
             # Now fetch the JSON API
             resp = await client.get(
@@ -67,35 +70,79 @@ class SegSocialSource(DataSource):
             return []
 
     async def search_by_nif(self, nif: str) -> dict[str, Any]:
-        """Search procedures by organism NIF or name match.
+        """Seg Social has no NIF filter — return empty and let
+        `_enrich_seg_social` in main.py resolve matches by company name.
 
-        The API doesn't support NIF filtering directly, so we fetch all
-        procedures and filter locally. The dataset is small (~200 records).
+        Previously this returned EVERY procedure from the API for every
+        NIF search, because the loop `matching.append(raw)` had no guard.
+        The card on the frontend then displayed ~200 unrelated
+        procedures for every company — loudly wrong for private
+        companies, misleading for public ones.
+
+        Returning empty here (instead of reusing `search_by_name`
+        blindly with the NIF) keeps the source's status reporting
+        intact without leaking unfiltered data into the report."""
+        return {
+            "seg_social_procedures": [],
+            "seg_social_organisms": [],
+        }
+
+    async def search_by_company_name(
+        self, name: str, acronym: str | None = None
+    ) -> dict[str, Any]:
+        """Filter procedures whose organism name/acronym matches the company.
+
+        Called as a name-based enrichment step AFTER entities/gleif/ptdata
+        have filled in `report.company.name`. Matching is intentionally
+        strict — substring match on the FULL name (not a token), plus
+        optional acronym match — because Seg Social organisms are
+        public-sector entities (ministries, universities, municipal
+        councils) and we don't want e.g. searching "EDP" to accidentally
+        match "Escola Dr. Pedro..." via a shared prefix.
         """
-        all_procs = await self._fetch_procedures()
+        query = (name or "").strip().lower()
+        acr = (acronym or "").strip().lower() if acronym else ""
+        if len(query) < 3:
+            # Short names produce too many false positives in substring
+            # matching; require a real name to avoid leaking noise.
+            return {"seg_social_procedures": [], "seg_social_organisms": []}
 
-        # Also fetch mobility procedures
+        try:
+            all_procs = await self._fetch_procedures()
+        except Exception as e:  # noqa: BLE001 - enrichment is best-effort
+            logger.warning(f"Seg Social fetch failed: {e}")
+            return {"seg_social_procedures": [], "seg_social_organisms": []}
+
+        # Also fetch mobility procedures — same endpoint, different type
         try:
             mobility_procs = await self._fetch_procedures("MOBILITY")
             all_procs.extend(mobility_procs)
-        except Exception:
-            pass  # Mobility endpoint might not exist
+        except Exception:  # noqa: BLE001 - MOBILITY endpoint may not exist
+            pass
 
-        # Filter by NIF in organism data or procedure text
-        matching = []
+        matching: list[dict] = []
         for raw in all_procs:
-            organism = raw.get("organism", {})
-            # Check if the organism NIF/name relates to our query
+            organism = raw.get("organism", {}) or {}
             org_name = str(organism.get("name", "")).lower()
-            proc_title = str(raw.get("title", "")).lower()
+            org_acronym = str(organism.get("acronym", "")).lower()
 
-            # Since the API doesn't expose organism NIFs directly,
-            # we store all procedures indexed by organism for future lookups
-            matching.append(raw)
+            # Match on full-name substring (company name contained in
+            # organism name, or vice-versa — public entities sometimes
+            # have a longer formal name than the user's search). Acronym
+            # match requires EXACT equality to avoid matching 3-letter
+            # fragments inside unrelated strings.
+            name_match = (
+                (query in org_name and org_name)
+                or (org_name and org_name in query)
+            )
+            acronym_match = bool(acr) and acr == org_acronym
+            if name_match or acronym_match:
+                matching.append(raw)
 
         procedures = [self._to_procedure(p) for p in matching]
 
-        # Group by organism for entity mapping
+        # Group by organism — same logic as before, but only for the
+        # filtered subset so orphaned organism badges don't leak.
         organisms: dict[str, SegSocialOrganism] = {}
         for proc in procedures:
             if proc.organism_name and proc.organism_id:

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -20,11 +20,14 @@ export default function App() {
   const [aiOverviewAvailable, setAiOverviewAvailable] = useState(false);
   const [chatAvailable, setChatAvailable] = useState(false);
 
-  // User preference — defaults to ON when the backend supports it. Stored
-  // in localStorage so the choice persists across sessions and tabs.
+  // User preference — OFF by default. AI overview is opt-in: users who
+  // want the LLM-generated narrative turn it on, everyone else sees the
+  // full data cards without the overview forcing the details section
+  // into collapsed-by-default mode. Stored in localStorage so the
+  // choice persists across sessions and tabs.
   const [aiOverviewEnabled, setAiOverviewEnabled] = usePreference(
     "aiOverview",
-    true,
+    false,
   );
   // Effective flag: only enable AI overview when BOTH the backend reports
   // it available (OPENAI_API_KEY configured) AND the user hasn't turned

--- a/frontend/src/components/EntityReport.tsx
+++ b/frontend/src/components/EntityReport.tsx
@@ -10,7 +10,9 @@ import { CompanyOverview } from "./CompanyOverview";
 import { CorporateGroupCard } from "./CorporateGroupCard";
 import { EUFundingCard } from "./EUFundingCard";
 import { MunicipalitiesCard } from "./MunicipalitiesCard";
-import { SegSocialCard } from "./SegSocialCard";
+// SegSocialCard intentionally NOT imported — see comment in the JSX
+// below for why. Component file is kept so the follow-up issue can
+// re-wire it once people-based matching lands.
 import { StreamSection, SkeletonHalfCard, SkeletonCard } from "./Skeleton";
 
 interface Props {
@@ -328,21 +330,15 @@ export function EntityReport({
               />
             </StreamSection>
 
-            {/* Segurança Social recruitment procedures — supplementary.
-                The backend has populated these fields since the initial
-                Seg Social source landed, but nothing was rendering them.
-                The card self-hides when there's no data, so private
-                companies don't see an empty "no procedures" section. */}
-            <StreamSection
-              source="seg_social"
-              report={report}
-              skeleton={<SkeletonCard lines={3} />}
-            >
-              <SegSocialCard
-                procedures={report.seg_social_procedures ?? []}
-                organisms={report.seg_social_organisms ?? []}
-              />
-            </StreamSection>
+            {/* Seg Social card intentionally NOT rendered here. The
+                correct match is people-based (cross-reference named
+                officers/directors in our report against candidates and
+                jury members listed in each procedure's PDF attachments)
+                — not organism-name-based. The required PDF-extraction
+                pipeline doesn't exist yet; tracked as a follow-up
+                issue. Rendering with a placeholder match would show
+                unrelated procedures to every user, which is worse than
+                showing nothing. */}
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Issues fixed

### 1. AI overview default → OFF
Previously defaulted to ON, which collapsed the details section (containing corporate group, contracts, etc.) by default. Users experienced corporate-group card as "disappeared". Now opt-in.

### 2. Seg Social showed every procedure for every NIF
The source's \`search_by_nif\` had a broken filter loop that appended every record (~200 records) regardless of NIF. My first attempt fixed it with organism-name matching, but the user correctly pointed out the matching should be **people-based** — cross-referencing named officers/directors in our report against candidates/jury members in each procedure's PDF attachments.

The required PDF-extraction + NER pipeline is a separate feature, tracked as issue #34. Until that lands:
- \`search_by_nif\` returns empty (no leaked data)
- \`SegSocialCard\` is not rendered in \`EntityReport.tsx\`
- The card component file is kept so the follow-up is a one-line re-import

### 3. AdC status stuck on "pending" in stream path
\`/api/search/stream\`'s \`source_coros\` dict was missing \`adc\` entirely — the task never ran, status never updated. Non-stream had it; this mirrors.

## Verification

Tested end-to-end against EDP (500697256):

| | Non-stream | Stream |
|---|---|---|
| corporate_group children | 46 ✓ | 46 ✓ |
| seg_social_procedures | 0 ✓ | 0 ✓ |
| adc status | ok ✓ | ok ✓ (was pending) |

\`ruff check\` clean; \`tsc --noEmit\` + \`vite build\` clean.

## Follow-up

- #34 — Seg Social: match procedures by people (PDF extraction + NER)

🤖 Generated with [Claude Code](https://claude.com/claude-code)